### PR TITLE
Add routers for service inference

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",
-  version := "0.1.0-SNAPSHOT",
+  version := "0.1.0",
   scalaVersion := "2.11.7",
   crossScalaVersions := Seq("2.10.5", "2.11.7")
 )
@@ -105,13 +105,14 @@ lazy val test = project
     .settings(libraryDependencies ++= testDependencies)
 
 lazy val example = project
+  .settings(resolvers += Resolver.sonatypeRepo("snapshots"))
   .settings(moduleName := "borderpatrol-example")
   .settings(allSettings)
   .settings(noPublish)
   .settings(
     libraryDependencies ++= Seq(
-      "com.github.finagle" %% "finch-core" % "0.7.1",
-      "com.github.finagle" %% "finch-argonaut" % "0.7.1"
+      "com.github.finagle" %% "finch-core" % "0.8.0",
+      "com.github.finagle" %% "finch-argonaut" % "0.8.0"
     )
   )
   .disablePlugins(JmhPlugin)
@@ -125,4 +126,14 @@ lazy val security = project
 lazy val auth = project
   .settings(moduleName := "borderpatrol-auth")
   .settings(allSettings)
+  .dependsOn(core, test % "test")
+
+lazy val server = project
+  .settings(moduleName := "borderpatrol-server")
+  .settings(allSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.github.finagle" %% "finch-core" % "0.8.0"
+    )
+  )
   .dependsOn(core, test % "test")

--- a/security/src/main/scala/com/lookout/borderpatrol/security/Csrf.scala
+++ b/security/src/main/scala/com/lookout/borderpatrol/security/Csrf.scala
@@ -1,5 +1,8 @@
 package com.lookout.borderpatrol.security
 
+/**
+ * This adds a double submit cookie CSRF protection layer to be used with authenticated endpoints
+ */
 object Csrf {
 
 }

--- a/server/src/main/scala/com/lookout/borderpatrol/routers/ServiceMatchers.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/routers/ServiceMatchers.scala
@@ -1,0 +1,66 @@
+package com.lookout.borderpatrol.routers
+
+import com.lookout.borderpatrol.routers.models.ServiceIdentifier
+import com.twitter.finagle.httpx.path.Path
+import com.twitter.util.{Try, Future}
+import io.finch.route._
+
+object ServiceMatchers {
+
+  /**
+   * Extrator for a default service
+   *
+   * @param f A function that takes a hostname and returns a serviceidentifier name
+   */
+  private[routers] case class DefaultService(name: String, f: String => Option[String])
+      extends Router[Option[String]] {
+
+    import Router._
+
+    override def apply(input: Input): Option[(Input, () => Future[Option[String]])] =
+      for {
+        h <- input.request.host
+      } yield (input.drop(1), () => Future.value(f(h)))
+  }
+
+  /**
+   * Provides the functions for Finch's Router/Extractor which require
+   * a signature of `String => Option[String]`
+   */
+  object ServicesMatcher {
+
+    val domainTerm = "."
+    val pathTerm = "/"
+
+    /**
+     * Find the longest matching subdomain that matches the host
+     *
+     * @example
+     *          Given a host of "sub.subdomain.example.org" and a Set[ServiceIdentifier] of
+     *            (ServiceIdentifier("one", "/s", "sub.subdomain"),
+     *             ServiceIdentifier("two", "/s2", "sub"))
+   *             return the ServiceIdentifier named "one" because it is the longest matching
+     * @param host The fully qualified host name
+     * @return the service name from the longest matching subdomain
+     */
+    def subdomain(host: String)(implicit services: Set[ServiceIdentifier]): Option[String] =
+      services.filter(si => host.startsWith(si.subdomain + domainTerm))
+              .foldRight(Option.empty[ServiceIdentifier])((si, res) => res match {
+                case Some(s) if si.subdomain.size < s.subdomain.size => Some(s)
+                case _ => Some(si)})
+              .map(_.name)
+
+    /**
+     * Find the path exactly matching the path in the request
+     *
+     * @param pathString path string from request
+     * @return the service name from the exact path match
+     */
+    def path(pathString: String)(implicit services: Set[ServiceIdentifier]): Option[String] = {
+      val path = Path(pathString)
+      services.find(_.path == path).map(_.name)
+    }
+
+  }
+
+}

--- a/server/src/main/scala/com/lookout/borderpatrol/routers/models.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/routers/models.scala
@@ -1,0 +1,35 @@
+package com.lookout.borderpatrol.routers
+
+import com.twitter.finagle.httpx.path.Path
+
+object models {
+
+  /**
+   * An identifier for Border Patrol to determine by `path` or
+   * by `subdomain` which service a request should be routed to
+   *
+   * @example
+   *          Let's say we have a service named "enterprise", if we
+   *          define the instance of that as:
+   *            {{{
+   *            val ent = Service("enterprise", Path("/ent"), "default")
+   *            val biz = Service("business", Path("/biz"), "api")
+   *            }}}
+   *
+   *          The following urls would match the services:
+   *            - api.example.com/ent => ent
+   *            - default.example.com/ => ent
+   *            - default.example.com/biz => biz
+   *            - api.example.com => biz
+   *            - api.example.com/ent => ent
+   *          These would not match the services:
+   *            - a.api.example.com => ???
+   *            - example.com => ???
+   *
+   * @param name The service name used for authentication
+   * @param path The external url path prefix that routes to the internal service
+   * @param subdomain A default fall-back when path is only `/`
+   */
+  case class ServiceIdentifier(name: String, path: Path, subdomain: String)
+
+}

--- a/server/src/main/scala/com/lookout/borderpatrol/routers/package.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/routers/package.scala
@@ -1,0 +1,5 @@
+package com.lookout.borderpatrol
+
+package object routers {
+
+}

--- a/server/src/test/scala/com/lookout/borderpatrol/routers/ServiceMatchersSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/routers/ServiceMatchersSpec.scala
@@ -1,0 +1,73 @@
+package com.lookout.borderpatrol.routers
+
+import com.lookout.borderpatrol.routers.models.ServiceIdentifier
+import com.twitter.finagle.httpx.{Status, RequestBuilder, Request}
+import com.twitter.finagle.httpx.path.Path
+import com.twitter.util.Await
+import io.finch.response.Ok
+import io.finch.route._
+import ServiceMatchers._
+import org.scalatest.{Matchers, FlatSpec}
+
+class ServiceMatchersSpec extends FlatSpec with Matchers {
+
+  val one = ServiceIdentifier("one", Path("/ent"), "enterprise")
+  val two = ServiceIdentifier("two", Path("/api"), "api")
+  val three = ServiceIdentifier("three", Path("/apis"), "api.subdomain")
+  implicit val sids = Set(one, two, three )
+
+  object servicePath extends Extractor("service", ServicesMatcher.path)
+  object rest extends TailExtractor("restOfPath", identity)
+  val subdomain = DefaultService("defaultService", ServicesMatcher.subdomain)
+
+  val router = (servicePath | subdomain) / rest /> { (sub, path) =>
+    Ok(sub.getOrElse(
+      if (path.isEmpty) "default"
+      else path.toString)
+    )
+  }
+  val service = router.toService
+
+  def req(subdomain: String = "nothing", path: Path = Path("/")): Request =
+    RequestBuilder().url(s"http://${subdomain + "."}example.com${path.toString}").buildGet()
+
+  behavior of "ServiceMatchers"
+
+  it should "default to subdomain match when path is /" in {
+    val fResults = for {
+      a <- service(req(one.subdomain))
+      b <- service(req(two.subdomain))
+      c <- service(req(three.subdomain))
+      d <- service(req(one.subdomain + "s"))
+      e <- service(req()) // failed
+    } yield List(a, b, c, d, e)
+    val results = Await.result( fResults.map(_.map(_.contentString)) )
+    results should be(List(one.name, two.name, three.name, "default", "default"))
+  }
+
+  it should "return the service name matching the exact path" in {
+    val fResults = for {
+      a <- service(req("a", one.path))
+      b <- service(req("a", two.path))
+      c <- service(req("a", three.path))
+      d <- service(req("a", Path(one.path.toString + "/other")))
+      e <- service(req("a", Path("/"))) // failed
+    } yield List(a, b, c, d, e)
+    val results = Await.result( fResults.map(_.map(_.contentString)) )
+    results should be(List(one.name, two.name, three.name, one.name, "default"))
+  }
+
+  it should "pass along the rest of the path when service path matching succeeds" in {
+    // /service/rest/of/path => match "service", => /rest/of/path
+    val service2 = ((servicePath | subdomain) / rest /> { (sub, path) => Ok(path.toString) }).toService
+    val pathTail = "/rest/of/path"
+    val inputPath = Path(one.path.toString + pathTail)
+
+    val expected = Path(pathTail).toList.toString
+    val results = Await.result(
+      service2(req("a", inputPath)).map(_.contentString)
+    )
+    results should be(expected)
+  }
+
+}


### PR DESCRIPTION
This adds the "borderpatrol-server" module to the project that will
include all of the business logic for running borderpatrol as a server.

The service inference is determined by
  1) path (e.g. /:service/rest/of/path)
  2) subdomain (e.g. http://<service.?>.example.com)

If the path is "/" then it defaults to the "subdomain"

Ref: #52