### PR TITLE
Fix build and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Border Patrol uses a multi-project structure and contains the following _modules
 services
 * [`auth`](auth) - different authentication plugins for core auth
 * [`security`](security) - different security plugins, e.g. CSRF protection
+* [`server`](server) - a server composing these modules that can be configured
 
 Installation
 ------------

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Encoder.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Encoder.scala
@@ -92,6 +92,10 @@ object SessionIdEncoder {
     str => SessionIdInjections.str2SessionId(str)
   )
 
+  /**
+   * A [[com.lookout.borderpatrol.sessionx.SessionIdEncoder SessionIdEncoder]] instance for
+   * [[com.twitter.finagle.httpx.Cookie Cookie]]
+   */
   implicit def encodeCookie(implicit secretStoreApi: SecretStoreApi): SessionIdEncoder[Cookie] = SessionIdEncoder(
     id => new Cookie("border_session", SessionId.toBase64(id)),
     cookie => SessionIdInjections.str2SessionId(cookie.value)

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/package.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/package.scala
@@ -63,9 +63,9 @@ import com.twitter.util.{Time, Future}
  * A [[com.lookout.borderpatrol.sessionx.Session Session]] is product type of a cryptographically verifiable
  * identifier [[com.lookout.borderpatrol.sessionx.SessionId SessionId]] and an arbitrary data type
  * A`. The only requirement for a [[com.lookout.borderpatrol.sessionx.SessionStore SessionStore]][B,M] to store/fetch
- * a `Session[A]` is that there be some implicit injective views from `A %> B` and `B %> Option[A]`.
+ * a `Session[A]` is that there be some implicit injective views from `A => B` and `B => Try[A]`.
  *
- * We have provided default views for: `httpx.Request %> Buf`, `Json %> Buf` and their injective views.
+ * We have provided default encodings for: `httpx.Request => Buf`, `String => Buf` and their injective views.
  *
  * {{{
  *  // set up secret/session stores
@@ -88,7 +88,7 @@ import com.twitter.util.{Time, Future}
  * }}}
  *
  * Let's say you have a [[com.lookout.borderpatrol.sessionx.Session.data Session.data]] type that doesn't have the
- * injective [[com.lookout.borderpatrol.view.View View]] that you need, that's OK!
+ * injective that you need, that's OK!
  * Assuming you are storing it in memcached, which requires a type of [[com.twitter.io.Buf Buf]] for the value:
  *
  * {{{
@@ -96,8 +96,10 @@ import com.twitter.util.{Time, Future}
  *     val value: Int
  *   }
  *
- *   implicit val foo2Int: Foo %> Buf = View(f => Buf.U32BE(f.value))
- *   implicit val int2OptFoo: Buf %> Option[Foo] = View(b => new Foo { override val value = Buf.U32BE.unapply(b) })
+ *   implicit val enc = SessionDataEncoder[Foo](
+ *     foo => Buf.U32BE(f.value),
+ *     buf => new Foo { override val value = Buf.U32BE.unapply(b) }
+ *   )
  *
  *   val foo1 = new Foo { override val value = 1 }
  *   val fooSession = Session(foo1)

--- a/server/src/main/scala/com/lookout/borderpatrol/server/ServiceMatchers.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/ServiceMatchers.scala
@@ -1,6 +1,6 @@
-package com.lookout.borderpatrol.routers
+package com.lookout.borderpatrol.server
 
-import com.lookout.borderpatrol.routers.models.ServiceIdentifier
+import com.lookout.borderpatrol.server.models.ServiceIdentifier
 import com.twitter.finagle.httpx.path.Path
 import com.twitter.util.{Try, Future}
 import io.finch.route._
@@ -44,7 +44,7 @@ object ServiceMatchers {
    *
    * @param f A function that takes a hostname and returns a serviceidentifier name
    */
-  private[routers] case class DefaultService(name: String, f: String => Option[String])
+  private[server] case class DefaultService(name: String, f: String => Option[String])
       extends Router[Option[String]] {
 
     import Router._

--- a/server/src/main/scala/com/lookout/borderpatrol/server/models.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/models.scala
@@ -1,4 +1,4 @@
-package com.lookout.borderpatrol.routers
+package com.lookout.borderpatrol.server
 
 import com.twitter.finagle.httpx.path.Path
 

--- a/server/src/main/scala/com/lookout/borderpatrol/server/package.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/package.scala
@@ -1,5 +1,5 @@
 package com.lookout.borderpatrol
 
-package object routers {
+package object server {
 
 }

--- a/server/src/main/scala/com/lookout/borderpatrol/server/readers.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/readers.scala
@@ -1,25 +1,26 @@
-package com.lookout.borderpatrol.routers
+package com.lookout.borderpatrol.server
 
+import com.lookout.borderpatrol.sessionx.SecretStoreApi
 import com.twitter.bijection.twitter_util.UtilBijections
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.httpx
 import com.twitter.util.Future
 import io.finch.request._
-import com.lookout.borderpatrol.sessionx._
 
 /**
  * A collection of RequestReader[A] types and functions to interact with requests
  * coming in to Border Patrol
  */
-class readers {
+object readers {
+  import com.lookout.borderpatrol.sessionx._
 
-  implicit val sessionIdDecoder: DecodeRequest[SessionId] =
+  implicit def sessionIdDecoder(implicit secretStoreApi: SecretStoreApi): DecodeRequest[SessionId] =
     DecodeRequest[SessionId](s => UtilBijections.twitter2ScalaTry.inverse(SessionId.from[String](s)))
 
   val sessionIdReader: RequestReader[SessionId] =
     cookie("border_session").map(_.value).as[SessionId]
 
-  def sessionReader(store: SessionStore): RequestReader[Session[Request]] =
-    sessionIdReader.embedFlatMap(store.get[Request]).embedFlatMap {
+  def sessionReader(store: SessionStore): RequestReader[Session[httpx.Request]] =
+    sessionIdReader.embedFlatMap(store.get[httpx.Request]).embedFlatMap {
       case Some(s) => Future.value(s)
       case None => Future.exception(new RequestError("invalid session"))
     }

--- a/server/src/main/scala/com/lookout/borderpatrol/server/services.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/services.scala
@@ -1,4 +1,4 @@
-package com.lookout.borderpatrol.routers
+package com.lookout.borderpatrol.server
 
 /**
  * This houses the two dependencies that Border Patrol has on authenticating requests

--- a/server/src/test/scala/com/lookout/borderpatrol/server/ServiceMatchersSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/ServiceMatchersSpec.scala
@@ -1,6 +1,6 @@
-package com.lookout.borderpatrol.routers
+package com.lookout.borderpatrol.server
 
-import com.lookout.borderpatrol.routers.models.ServiceIdentifier
+import com.lookout.borderpatrol.server.models.ServiceIdentifier
 import com.twitter.finagle.httpx.{RequestBuilder, Request}
 import com.twitter.finagle.httpx.path.Path
 import com.twitter.util.Await


### PR DESCRIPTION
The build was failing because of missing implicits in server.readers,
this was just an oversight that wasn't caught because we have no tests
in server yet.

Further, server was misnamed as "routers", so this was changed.

Ref: #52