### PR TITLE
Add tut to parse markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Documentation
 -------------
 
 * Scaladoc is available at [http://lookout.github.io/borderpatrol/docs](http://hackers.lookout.com/borderpatrol/docs/#com.lookout.borderpatrol.package)
-
+* Markdown documents are available [here](https://github.com/lookout/borderpatrol/tree/master/docs/src/main/tut).  The code examples are fully runnable in a Scala REPL verified with [tut](https://github.com/tpolecat/tut).  Use `sbt tut` to compile example code in markdown (`docs/src/main/tut`) which outputs to `target/scala-N.NN/tut`
 
 Contributing
 ------------

--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,10 @@ lazy val publishSettings = Seq(
   bintrayOrganization := Some("lookout")
 )
 
+lazy val tutExtraSettings = Seq(
+  tutSourceDirectory := baseDirectory.value / "docs" / "src" / "main" / "tut"
+)
+
 lazy val noPublish = Seq(
   publish := {},
   publishLocal := {}
@@ -71,7 +75,7 @@ lazy val noPublish = Seq(
 
 lazy val allSettings = baseSettings ++ buildSettings ++ publishSettings
 
-lazy val docSettings = site.settings ++ ghpages.settings ++ unidocSettings ++ Seq(
+lazy val docSettings = tutExtraSettings ++ site.settings ++ ghpages.settings ++ unidocSettings ++ Seq(
   site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "docs"),
   git.remoteRepo := s"git@github.com:lookout/borderpatrol.git",
   unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject
@@ -81,6 +85,8 @@ lazy val root = project.in(file("."))
   .settings(moduleName := "borderpatrol")
   .settings(allSettings)
   .settings(docSettings)
+  .settings(tutSettings)
+  .settings(tutExtraSettings)
   .settings(noPublish)
   .settings(
     initialCommands in console :=

--- a/docs/src/main/tut/Borderpatrol.md
+++ b/docs/src/main/tut/Borderpatrol.md
@@ -1,0 +1,95 @@
+Border Patrol introduces types and functions that enable identifying, fetching, and storing web session data. This
+is accomplished by a set of types that will be used by consumers of this library: `Session`, `Store`, and `Secret`.
+
+A `com.lookout.borderpatrol.sessionx.Secret Secret` is a cryptographically verifiable signing key used to sign a
+`com.lookout.borderpatrol.sessionx.SessionId SessionId`. Creating a `Secret` is simple. It defaults to expire at
+`com.lookout.borderpatrol.sessionx.Secret.lifetime Secret.lifetime`
+
+
+```tut:silent
+import argonaut._, Argonaut._
+import com.twitter.util.{Time, Await}
+import com.twitter.finagle.httpx.Cookie
+import com.lookout.borderpatrol.sessionx.{Secret, Secrets, Session, SessionId, SessionStore, SessionDataEncoder}
+import com.lookout.borderpatrol.sessionx.crypto.Generator.EntropyGenerator
+import com.lookout.borderpatrol.sessionx.SecretStores.InMemorySecretStore
+import com.lookout.borderpatrol.sessionx.SecretStores
+import com.twitter.finagle.httpx
+import com.twitter.io.Buf
+```
+
+```tut
+  val secret = Secret() // default secret expiry
+  val expiringSecret = Secret(Time.now)
+
+  val randomBytes = EntropyGenerator(16) // 16 bytes of randomness
+  val randomId = EntropyGenerator(1).head // 1 byte of randomness for an id
+  val expiry = Time.fromSeconds(0) // very expired
+  val constructedSecret = Secret(randomId, expiry, randomBytes)
+  println(s"secret has expired: ${constructedSecret.expired == true}")
+
+  val signedMsg = secret.sign("message to by signed".getBytes)
+```
+
+A `com.lookout.borderpatrol.sessionx.SessionId SessionId` is a cryptographically signed identifier for a
+`com.lookout.borderpatrol.sessionx.Session Session`, it consists of entropy, expiry, secret,and signature of those
+items. This is meant to be used as the `com.twitter.finagle.httpx.Cookie` value, so we provide serializing to
+`String`.
+
+```tut
+  implicit val secretStore = SecretStores.InMemorySecretStore(Secrets(Secret(), Secret()))
+  val id: SessionId = Await.result(SessionId.next)
+  val cookieValue: String = id.asBase64
+  SessionId.from[String](cookieValue) == id
+```
+
+A `com.lookout.borderpatrol.sessionx.Session Session` is product type of a cryptographically verifiable
+identifier `com.lookout.borderpatrol.sessionx.SessionId SessionId` and an arbitrary data type
+A`. The only requirement for a `com.lookout.borderpatrol.sessionx.SessionStore SessionStore`[B,M] to store/fetch
+a `Session[A]` is that there be some implicit injective views from `A => B` and `B => Try[A]`.
+
+We have provided default encodings for: `httpx.Request => Buf`, `String => Buf` and their injective views.
+
+```tut
+   implicit val encodeRequest: SessionDataEncoder[httpx.Request] = SessionDataEncoder(
+     data => Buf.ByteArray.Owned(data.encodeBytes()),
+     buf => httpx.Request.decodeBytes(Buf.ByteArray.Owned.extract(buf))
+   )
+
+ // set up secret/session stores
+ implicit val secretStore = SecretStores.InMemorySecretStore(Secrets(Secret(), Secret()))
+ val sessionStore = SessionStore.InMemoryStore
+
+ // create a Session[httpx.Request]
+ val newSessionFuture = Session(httpx.Request("http://localhost/api/stuff")) // entropy is blocking on the JVM
+ val newSession = Await.result(newSessionFuture)
+
+ // see if the session expired (checks the `SessionId.expires`)
+ println(s"Session has expired? ${newSession.expired}")
+
+ // store the session and then fetch it
+ sessionStore.update(newSession).onFailure(println)
+ sessionStore.get(newSession.id).onSuccess(s => s match {
+   case Some(s) => println(s"Same session?: ${newSession == s}")
+   case None => println("hrm, where did the session go?")
+ })
+```
+
+Let's say you have a `com.lookout.borderpatrol.sessionx.Session.data Session.data` type that doesn't have the
+injective that you need, that's OK!
+Assuming you are storing it in memcached, which requires a type of `com.twitter.io.Buf Buf` for the value:
+
+```tut
+  trait Foo {
+    val value: Int
+  }
+
+  implicit val enc = SessionDataEncoder[Foo](
+    foo => Buf.U32BE(foo.value),
+    buf => new Foo { override val value = Buf.U32BE.unapply(buf).get._1 }
+  )
+
+  val foo1 = new Foo { override val value = 1 }
+  val fooSession = Session(foo1)
+  sessionStore.update(Await.result(fooSession))
+```

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,10 @@ resolvers ++= Seq(
   "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/",
   Resolver.jcenterRepo
 )
+resolvers += Resolver.url(
+  "tpolecat-sbt-plugin-releases",
+    url("http://dl.bintray.com/content/tpolecat/sbt-plugin-releases"))(
+        Resolver.ivyStylePatterns)
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
@@ -15,3 +19,4 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
 addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.13")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.15")
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.0")


### PR DESCRIPTION
Adds a /tut directory in project root to store markdown files.
Parses MD files and stores output in target/scala-N.NN/tut.

Refs: #2, #54