### PR TITLE
Fix tut compilation of markdown files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,10 +64,6 @@ lazy val publishSettings = Seq(
   bintrayOrganization := Some("lookout")
 )
 
-lazy val tutExtraSettings = Seq(
-  tutSourceDirectory := baseDirectory.value / "docs" / "src" / "main" / "tut"
-)
-
 lazy val noPublish = Seq(
   publish := {},
   publishLocal := {}
@@ -75,18 +71,18 @@ lazy val noPublish = Seq(
 
 lazy val allSettings = baseSettings ++ buildSettings ++ publishSettings
 
-lazy val docSettings = tutExtraSettings ++ site.settings ++ ghpages.settings ++ unidocSettings ++ Seq(
+lazy val docSettings = site.settings ++ ghpages.settings ++ unidocSettings ++ Seq(
   site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "docs"),
   git.remoteRepo := s"git@github.com:lookout/borderpatrol.git",
-  unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject
+  unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject,
+  tutSourceDirectory := baseDirectory.value / "docs" / "src" / "main" / "tut"
 )
 
 lazy val root = project.in(file("."))
   .settings(moduleName := "borderpatrol")
   .settings(allSettings)
-  .settings(docSettings)
   .settings(tutSettings)
-  .settings(tutExtraSettings)
+  .settings(docSettings)
   .settings(noPublish)
   .settings(
     initialCommands in console :=

--- a/docs/src/main/tut/Borderpatrol.md
+++ b/docs/src/main/tut/Borderpatrol.md
@@ -6,12 +6,12 @@ A `com.lookout.borderpatrol.sessionx.Secret Secret` is a cryptographically verif
 `com.lookout.borderpatrol.sessionx.Secret.lifetime Secret.lifetime`
 
 
-```tut:silent
+```tut
 import argonaut._, Argonaut._
 import com.twitter.util.{Time, Await}
 import com.twitter.finagle.httpx.Cookie
 import com.lookout.borderpatrol.sessionx.{Secret, Secrets, Session, SessionId, SessionStore, SessionDataEncoder}
-import com.lookout.borderpatrol.sessionx.crypto.Generator.EntropyGenerator
+import com.lookout.borderpatrol.crypto.Generator
 import com.lookout.borderpatrol.sessionx.SecretStores.InMemorySecretStore
 import com.lookout.borderpatrol.sessionx.SecretStores
 import com.twitter.finagle.httpx
@@ -22,8 +22,8 @@ import com.twitter.io.Buf
   val secret = Secret() // default secret expiry
   val expiringSecret = Secret(Time.now)
 
-  val randomBytes = EntropyGenerator(16) // 16 bytes of randomness
-  val randomId = EntropyGenerator(1).head // 1 byte of randomness for an id
+  val randomBytes = Generator.EntropyGenerator(16) // 16 bytes of randomness
+  val randomId = Generator.EntropyGenerator(1).head // 1 byte of randomness for an id
   val expiry = Time.fromSeconds(0) // very expired
   val constructedSecret = Secret(randomId, expiry, randomBytes)
   println(s"secret has expired: ${constructedSecret.expired == true}")


### PR DESCRIPTION
    Borderpatrol.md had incorrect imports.  Also, re-arranged
    docSettings to appear after tutSettings so that tut modifiers
    could be called in the docSettings.

    Refs: #2, #54