### PR TITLE
Add LoginFilter for Keymaster

### DIFF
--- a/core/src/main/scala/com/lookout/borderpatrol/auth/Identity.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/Identity.scala
@@ -31,7 +31,7 @@ case object EmptyIdentity extends Identity[Nothing]
 case class Id[+A](id: A) extends Identity[A]
 
 object Identity {
-  def apply[A](a: A): Identity[A] =
+  def apply[A](a: A): Id[A] =
     Id(a)
 }
 
@@ -52,7 +52,7 @@ trait IdentifyRequest[A] {
  * Example: SAML POST response to a successful login to a third party IdP
  */
 trait IdentifyResponse[A] {
-  val identity: Identity[A]
+  val identity: Id[A]
 }
 
 /**

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionStoreSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionStoreSpec.scala
@@ -10,8 +10,8 @@ class SessionStoreSpec extends BorderPatrolSuite {
 
   behavior of "SessionStore"
 
-  val sessionStore = SessionStore.InMemoryStore
-  val memcachedSessionStore = SessionStore.MemcachedStore(new memcached.MockClient())
+  val sessionStore = SessionStores.InMemoryStore
+  val memcachedSessionStore = SessionStores.MemcachedStore(new memcached.MockClient())
   val intSession = sessions.create(1)
   val strSession = sessions.create("hello")
   val reqSession = sessions.create(httpx.Request("localhost:8080/api/hello"))
@@ -46,6 +46,13 @@ class SessionStoreSpec extends BorderPatrolSuite {
       /* TODO: Disallow this: Int -> Buf -> String
       isThrow(store.get[Int](strSession.id)) should be(false)
       */
+    }
+
+    it should s"delete stored values in $store" in {
+      store.update(intSession)
+      store.get[Int](intSession.id).results shouldBe Some(intSession)
+      store.delete(intSession.id)
+      store.get[Int](intSession.id).results shouldBe None
     }
   }
 

--- a/example/src/main/scala/com/lookout/borderpatrol/example/reader.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/reader.scala
@@ -36,7 +36,7 @@ object reader {
   import model._
 
   implicit val secretStore = SecretStores.InMemorySecretStore(Secrets(Secret(), Secret()))
-  implicit val sessionStore = SessionStore.InMemoryStore
+  implicit val sessionStore = SessionStores.InMemoryStore
 
   implicit val sessionIdDecoder: DecodeRequest[SessionId] =
     DecodeRequest[SessionId](s => UtilBijections.twitter2ScalaTry.inverse(SessionId.from[String](s)))


### PR DESCRIPTION
This login filter will listen to the login service's POST and transform
the request into a IndentifyRequest[Credential] that Keymaster can
understand. Once Keymaster has succesfully provided the identity, that
identity is saved to a new session pointer and the user is redirected to
their original request location with a new cookie

It will also remove the old session, as it is no longer valid