### PR TITLE
Add CSRF protection filter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",
-  version := "0.1.0",
+  version := "0.1.0-SNAPSHOT",
   scalaVersion := "2.11.7",
   crossScalaVersions := Seq("2.10.5", "2.11.7")
 )
@@ -87,23 +87,23 @@ lazy val root = project.in(file("."))
   .settings(
     initialCommands in console :=
       """
+        |import com.lookout.borderpatrol._
         |import com.lookout.borderpatrol.sessionx._
         |import com.lookout.borderpatrol.auth._
       """.stripMargin
     )
-  .aggregate(core, example, security, auth)
-  .dependsOn(core)
+  .aggregate(core, example, security, auth, test)
+  .dependsOn(core, auth)
 
 lazy val core = project
   .settings(moduleName := "borderpatrol-core")
   .settings(allSettings)
-  .dependsOn(test % "test")
 
 lazy val test = project
-    .settings(moduleName := "borderpatrol-test")
-    .settings(allSettings)
-    .settings(coverageExcludedPackages := "com\\.lookout\\.borderpatrol\\.test\\..*")
-    .settings(libraryDependencies ++= testDependencies)
+  .settings(moduleName := "borderpatrol-test")
+  .settings(allSettings)
+  .settings(libraryDependencies ++= testDependencies)
+  .dependsOn(core)
 
 lazy val example = project
   .settings(resolvers += Resolver.sonatypeRepo("snapshots"))
@@ -117,12 +117,12 @@ lazy val example = project
     )
   )
   .disablePlugins(JmhPlugin)
-  .dependsOn(core, auth)
+  .dependsOn(core, auth, test % "test")
 
 lazy val security = project
   .settings(moduleName := "borderpatrol-security")
   .settings(allSettings)
-  .dependsOn(core, test % "test")
+  .dependsOn(core % "test->test;compile->compile")
 
 lazy val auth = project
   .settings(moduleName := "borderpatrol-auth")
@@ -134,6 +134,5 @@ lazy val auth = project
       "io.circe" %% "circe-jawn" % "0.1.1"
     )
   )
-  .aggregate(core)
-  .dependsOn(core % "test->test;compile->compile", test % "test")
+  .dependsOn(core % "test->test;compile->compile")
 

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Encoder.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Encoder.scala
@@ -142,7 +142,8 @@ object SessionIdEncoder {
   /**
    * Helper method for creating new [[com.lookout.borderpatrol.sessionx.SessionIdEncoder]] instances
    */
-  def apply[A](f: SessionId => A, g: A => Try[SessionId]): SessionIdEncoder[A] =
+  def apply[A](f: SessionId => A, g: A => Try[SessionId])(implicit secretStoreApi: SecretStoreApi):
+      SessionIdEncoder[A] =
     new SessionIdEncoder[A] {
       def encode(id: SessionId): A = f(id)
       def decode(a: A): Try[SessionId] = g(a)

--- a/security/src/main/scala/com/lookout/borderpatrol/security/Csrf.scala
+++ b/security/src/main/scala/com/lookout/borderpatrol/security/Csrf.scala
@@ -1,8 +1,58 @@
 package com.lookout.borderpatrol.security
 
-/**
- * This adds a double submit cookie CSRF protection layer to be used with authenticated endpoints
- */
-object Csrf {
+import com.lookout.borderpatrol.util.Combinators.tap
+import com.lookout.borderpatrol.sessionx._
+import com.twitter.finagle.{Service, Filter}
+import com.twitter.finagle.httpx.{Request, Response}
+import com.twitter.util.Future
 
+object Csrf {
+  case class InHeader(val header: String = "X-BORDER-CSRF") extends AnyVal
+  case class Param(val param: String = "_x_border_csrf") extends AnyVal
+  case class CookieName(val name: String = "border_csrf") extends AnyVal
+  case class VerifiedHeader(val header: String = "X-BORDER-CSRF-VERIFIED") extends AnyVal
+
+  /**
+   * Informs upstream service about Csrf validation via double submit cookie
+   *
+   * @param header The incoming header that contains the CSRF token
+   * @param param The incoming parameter that contains the CSRF token
+   * @param cookieName The cookie that contains the CSRF token
+   * @param verifiedHeader The verified header to set
+   */
+  case class Verify(header: InHeader,
+                    param: Param,
+                    cookieName: CookieName,
+                    verifiedHeader: VerifiedHeader)(implicit secretStoreApi: SecretStoreApi) {
+
+    /**
+     * Inject the value of the call to verify in the VerifiedHeader
+     * It's unsafe, because it mutates the Request
+     */
+    def unsafeInject(req: Request)(f: Boolean => String): Request =
+      tap(req)(_.headerMap.set(verifiedHeader.header, f(verify(req))))
+
+    /**
+     * Check that CSRF header/param is there, validates that the cookie and header/param are valid SessionIds
+     * If the header is not present it will look for the parameter.
+     * @return false unless all checks are valid
+     */
+    def verify(req: Request): Boolean =
+      (for {
+        str <- req.headerMap.get(header.header) orElse req.params.get(param.param)
+        ckv <- req.cookies.getValue(cookieName.name)
+        uid <- SessionId.from(str).toOption
+        cid <- SessionId.from(ckv).toOption
+      } yield uid == cid) getOrElse false
+  }
+}
+
+/**
+ * Sets the CSRF header for inspection by upstream service. Always sets csrf verified header to false unless
+ * the csrf cookie and the header/param match and are valid.
+ */
+case class CsrfFilter(verify: Csrf.Verify) extends Filter[Request, Response, Request, Response] {
+
+  def apply(req: Request, service: Service[Request, Response]): Future[Response] =
+    service(verify.unsafeInject(req)(_.toString))
 }

--- a/security/src/test/scala/com/lookout/borderpatrol/test/security/CsrfSpec.scala
+++ b/security/src/test/scala/com/lookout/borderpatrol/test/security/CsrfSpec.scala
@@ -1,0 +1,109 @@
+package com.lookout.borderpatrol.test.security
+
+import com.lookout.borderpatrol.security.Csrf._
+import com.lookout.borderpatrol.security.CsrfFilter
+import com.lookout.borderpatrol.test._
+import com.twitter.finagle.Service
+import com.twitter.finagle.httpx.{Response, Cookie, Request, Status}
+import com.twitter.util.Future
+
+class CsrfSpec extends BorderPatrolSuite {
+  import com.lookout.borderpatrol.test.sessionx.helpers._
+
+  val csrf1 = sessionid.next.asBase64
+  val csrf2 = sessionid.next.asBase64
+
+  val (header, param, cookiename, verified) = ("header", "param", "cookieName", "verified")
+  val verify = Verify(InHeader(header), Param(param), CookieName(cookiename), VerifiedHeader(verified))
+
+  def requestWithHeader: Request = {
+    val req = Request("/")
+    req.addCookie(new Cookie(cookiename, csrf1))
+    req.headerMap.add(header, csrf1)
+    req
+  }
+
+  def requestWithParam: Request = {
+    val req = Request("/", param -> csrf1)
+    req.addCookie(new Cookie(cookiename, csrf1))
+    req
+  }
+
+  behavior of "Verify"
+  it should "return a request with a verified header set" in {
+    val req = Request("/")
+    verify.unsafeInject(req)(_.toString)
+
+    req.headerMap.get(verified) should not be(None)
+    req.headerMap.get(verified).value should be(false.toString)
+  }
+
+  it should "set verified header as true when Csrf header or param is set correctly" in {
+    val req1 = requestWithHeader
+    val req2 = requestWithParam
+
+    verify.unsafeInject(req1)(_.toString)
+    verify.unsafeInject(req2)(_.toString)
+
+    req1.headerMap.get(verified) should not be(None)
+    req2.headerMap.get(verified) should not be(None)
+    req1.headerMap.get(verified).value should be(true.toString)
+    req2.headerMap.get(verified).value should be(true.toString)
+  }
+
+  it should "set verified header as false when Csrf header or param is set incorrectly" in {
+    val req1 = requestWithHeader
+    val req2 = Request("/", param -> csrf2)
+    req1.headerMap.update(header, csrf2)
+    req2.addCookie(new Cookie(cookiename, csrf1))
+
+    verify.unsafeInject(req1)(_.toString)
+    verify.unsafeInject(req2)(_.toString)
+
+    req1.headerMap.get(verified) should not be(None)
+    req2.headerMap.get(verified) should not be(None)
+    req1.headerMap.get(verified).value should be(false.toString)
+    req2.headerMap.get(verified).value should be(false.toString)
+  }
+
+  it should "set verified header as false when Csrf cookie is set incorrectly" in {
+    val req1 = requestWithHeader
+    val req2 = requestWithParam
+    req1.cookies.remove(cookiename)
+    req2.cookies.update(cookiename, new Cookie(cookiename, csrf2))
+
+    verify.unsafeInject(req1)(_.toString)
+    verify.unsafeInject(req2)(_.toString)
+
+    req1.headerMap.get(verified) should not be(None)
+    req2.headerMap.get(verified) should not be(None)
+    req1.headerMap.get(verified).value should be(false.toString)
+    req2.headerMap.get(verified).value should be(false.toString)
+  }
+  behavior of "CsrfFilter"
+  val filter = CsrfFilter(verify)
+  val service = Service.mk[Request, Response]{ req =>
+    Future.value {
+      req.headerMap.get(verified) match {
+        case Some("true") => Response(Status.Ok)
+        case Some("false") => Response(Status.Forbidden)
+        case _ => throw new Exception("bottom")
+      }
+    }
+  }
+
+  it should "make an Ok response when verify sets header to true" in {
+    filter(requestWithParam, service).results.status should be(Status.Ok)
+  }
+
+  it should "make a Forbidden response when verify sets header to false" in {
+    filter(Request("/"), service).results.status should be(Status.Forbidden)
+  }
+
+  it should "override any verified header set in incoming request" in {
+    val req = Request("/")
+    req.headerMap.add(verified, true.toString)
+    filter(req, service).results.status should be(Status.Forbidden)
+  }
+
+}


### PR DESCRIPTION
This commit provides upstream services with a way to do CSRF without
needing to be stateful themselves. Instead, they need only communicate
with Border Patrol via two options:
 - Header (useful for javascript single page apps)
 - Query parameter (useful for all others)

Upon successful login, the user should be presented with a CSRF cookie
whos value upstreams will use to inject into requests for Border Patrol
to verify that there is no CSRF vulnerability. This pattern is known as
Double Submit Cookie.

The request will be routed through Border Patrol which will inspect both
the header or param, and the cookie value that each matches. Since we
use the capabilities of the SessionId, we also get the cryptographic
attributes in this CSRF cookie.

Once Border Patrol has verified the incoming CSRF header/param and
cookie it will inject a "verified" header with a configurable value (the
CsrfFilter just calls .toString on a Boolean)

The values for these headers are configurable, but have sane defaults
that shouldn't cause conflicts in services or existing headers or
parameters.

Fixes #48