### PR TITLE
Use json for entire config and validate the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,35 @@ installed (prefer v0.13.8+). Run `sbt`, and then use any of the following comman
  * `scalastyle`: run the style-checker on the code
  * `validate`: run tests, style-checker, and doc generation
 
+Configuration
+-------------
+
+ * `secretStore`: Secret Store used to store Secrets (TBD)
+ * `sessionStore`: Session Store (TBD)
+ * `accessManagers`: A list of ACCESS `Manager`s. Access endpoints authorize access to protected endpoints.
+ * `identityManagers`: A list of IDENTITY `Manager`s. Identity managers perform authentication and provisioning
+ * `Manager`: A
+     * `hosts`: A list of upstream URLs (Format: `[<http[s]>://<host>:[port]]+`)
+     * `path`: A path serviced by the upstream manager (i.e. Keymaster IDP endpoint or Keymaster AccesIssuer endpoint)
+     * `name`: A unique name that identifies this Manager
+ * `loginManagers`: A list of LOGIN `Manager`s
+ * `loginManager`: It defines a
+     * `hosts`: A list of upstream URLs (Format: `[<http[s]>://<host>:[port]]+`)
+     * `path`: A path serviced by  the upstream host (i.e. login provider host). It typically services the
+ un-authenticated web services
+     * `name`:  unique name that identifies this Login Manager
+     * `identityManager`: Identity manager name used by this Login Manager
+     * `accessManager`: Access Issuer used by this Login Manager
+     * `loginPath`: The path at which login form posts the login response
+ * `serviceIdentifiers`: A list of protected service endpoints
+ * `serviceIdentifier`: A protected service endpoint. The combination of subdomain and path uniqully identifies
+ service.
+     * `hosts`: A list of upstream URLs (Format: `[<http[s]>://<host>:[port]]+`)
+     * `name`: A unique name that identifies this Service Identifier
+     * `loginManager`: Login Manager used by this Service Identifier
+     * `path`: A path serviced by the protected endpoint
+     * `subdomain`: A subdomain of the protected endpoint
+
 Running the example
 -------------------
 

--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
@@ -2,7 +2,8 @@ package com.lookout.borderpatrol.auth.keymaster
 
 import com.lookout.borderpatrol.util.Combinators.tap
 import com.lookout.borderpatrol.sessionx._
-import com.lookout.borderpatrol.ServiceIdentifier
+import com.lookout.borderpatrol._
+import com.lookout.borderpatrol.Binder._
 import com.lookout.borderpatrol.auth._
 import com.twitter.finagle.httpx.path.Path
 import com.twitter.finagle.{Filter, Service}
@@ -23,22 +24,25 @@ object Keymaster {
   /**
    * The identity provider for Keymaster, will connect to the remote keymaster server to authenticate and get an
    * identity (master token)
-   * @param client Keymaster service
-   * @param path Keymaster service endpoint path
+   * @param binder Binder to bind to Keymaster identity service
    */
-  case class KeymasterIdentityProvider(client: Service[Request, Response], path: Path)
+  case class KeymasterIdentityProvider(binder: ManagerBinder)
       extends IdentityProvider[Credential, Tokens] {
 
     def api(cred: Credential): Request =
-      Request(Method.Post,
-        Request.queryString(path.toString, ("e", cred.email), ("p", cred.password), ("s", cred.serviceId.name)))
+      tap(Request(Method.Post,  cred.serviceId.loginManager.identityManager.path.toString))(req => {
+        req.contentType = "application/x-www-form-urlencoded"
+        req.contentString = Request.queryString(("e", cred.email), ("p", cred.password), ("s", cred.serviceId.name))
+          .drop(1) /* Drop '?' */
+      })
 
     /**
      * Sends credentials, if authenticated successfully will return a MasterToken otherwise a Future.exception
      */
     def apply(req: IdentifyRequest[Credential]): Future[IdentifyResponse[Tokens]] =
       //  Authenticate user by the Keymaster
-      client(api(req.credential)).flatMap(res => res.status match {
+      binder(BindRequest(req.credential.serviceId.loginManager.identityManager, api(req.credential)))
+        .flatMap(res => res.status match {
         //  Parse for Tokens if Status.Ok
         case Status.Ok =>
           Tokens.derive[Tokens](res.contentString).fold[Future[IdentifyResponse[Tokens]]](
@@ -98,29 +102,32 @@ object Keymaster {
    * - Get is directed to login form
    * - Post processes the login credentials
    *
-   * @param client
+   * @param binder
    */
-  case class KeymasterMethodMuxLoginFilter(client: Service[Request, Response], loginPath: Path)
+  case class KeymasterMethodMuxLoginFilter(binder: LoginManagerBinder)
     extends Filter[SessionIdRequest, Response, SessionIdRequest, Response] {
     def apply(req: SessionIdRequest,
               service: Service[SessionIdRequest, Response]): Future[Response] =
       (req.req.req.method, req.req.req.path) match {
         case (Method.Post, loginPath) => service(req)
-        case _ => client(req.req.req)
+        case _ => binder(BindRequest(req.req.serviceId.loginManager, req.req.req))
       }
   }
 
   /**
    * The access issuer will use the MasterToken to gain access to service tokens
-   * @param client Keymaster service
-   * @param path Keymaster service endpoint path
+   * @param binder Keymaster Access Service Binder
    * @param store Session store
    */
-  case class KeymasterAccessIssuer(client: Service[Request, Response], path: Path, store: SessionStore)
+  case class KeymasterAccessIssuer(binder: ManagerBinder, store: SessionStore)
       extends AccessIssuer[Tokens, ServiceToken] {
-    def api(req: AccessRequest[Tokens]): Request =
-      tap(Request(Method.Post, Request.queryString(path.toString(),
-        ("services" -> req.serviceId.name))))(r => r.headerMap.add("Auth-Token", req.identity.id.master.value))
+    def api(accessRequest: AccessRequest[Tokens]): Request =
+      tap(Request(Method.Post, accessRequest.serviceId.loginManager.accessManager.path.toString))(req => {
+        req.contentType = "application/x-www-form-urlencoded"
+        req.contentString = Request.queryString(("services" -> accessRequest.serviceId.name))
+          .drop(1) /* Drop '?' */
+        req.headerMap.add("Auth-Token", accessRequest.identity.id.master.value)
+      })
 
     /**
      * Fetch a valid ServiceToken, will return a ServiceToken otherwise a Future.exception
@@ -129,7 +136,7 @@ object Keymaster {
       //  Check if ServiceToken is already available for Service
       req.identity.id.service(req.serviceId.name).fold[Future[ServiceToken]](
         //  Fetch ServiceToken from the Keymaster
-        client(api(req)).flatMap(res => res.status match {
+        binder(BindRequest(req.serviceId.loginManager.accessManager, api(req))).flatMap(res => res.status match {
           //  Parse for Tokens if Status.Ok
           case Status.Ok =>
             Tokens.derive[Tokens](res.contentString).fold[Future[ServiceToken]](
@@ -152,14 +159,37 @@ object Keymaster {
   /**
    * This filter acquires the access and then forwards the request to upstream service
    *
-   * @param upstreamClient
+   * @param binder Upstream Service Binder
    */
-  case class KeymasterAccessFilter(upstreamClient: Service[Request, Response])
+  case class KeymasterAccessFilter(binder: ServiceIdentifierBinder)
       extends Filter[AccessIdRequest[Tokens], Response, AccessRequest[Tokens], AccessResponse[ServiceToken]] {
     def apply(req: AccessIdRequest[Tokens],
               accessService: Service[AccessRequest[Tokens], AccessResponse[ServiceToken]]): Future[Response] =
       accessService(AccessRequest(req.id, req.req.req.serviceId, req.req.sid)).flatMap(accessResp =>
-        upstreamClient(tap(req.req.req.req) { r => r.headerMap.add("Auth-Token", accessResp.access.access.value)})
+        binder(BindRequest(req.req.req.serviceId,
+          tap(req.req.req.req) { r => r.headerMap.add("Auth-Token", accessResp.access.access.value)}))
       )
+  }
+
+  /**
+   *  Keymaster Identity provider service Chain
+   * @param store
+   */
+  def keymasterIdentityProviderChain(store: SessionStore)(
+    implicit secretStoreApi: SecretStoreApi): Service[SessionIdRequest, Response] = {
+    new KeymasterMethodMuxLoginFilter(new LoginManagerBinder) andThen
+      new KeymasterPostLoginFilter(store) andThen
+      new KeymasterIdentityProvider(new ManagerBinder)
+  }
+
+  /**
+   * Keymaster Access Issuer service Chain
+   * @param store
+   */
+  def keymasterAccessIssuerChain(store: SessionStore)(
+    implicit secretStoreApi: SecretStoreApi): Service[SessionIdRequest, Response] = {
+    new IdentityFilter[Tokens](store) andThen
+      new KeymasterAccessFilter(new ServiceIdentifierBinder) andThen
+      new KeymasterAccessIssuer(new ManagerBinder, store)
   }
 }

--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
@@ -24,7 +24,7 @@ object Keymaster {
   /**
    * The identity provider for Keymaster, will connect to the remote keymaster server to authenticate and get an
    * identity (master token)
-   * @param binder Binder to bind to Keymaster identity service
+   * @param binder Binder that binds to Keymaster identity service passed in the IdentityManager
    */
   case class KeymasterIdentityProvider(binder: MBinder[Manager])
       extends IdentityProvider[Credential, Tokens] {
@@ -102,7 +102,7 @@ object Keymaster {
    * - Get is directed to login form
    * - Post processes the login credentials
    *
-   * @param binder
+   * @param binder It binds to upstream login provider using the information passed in LoginManager
    */
   case class KeymasterMethodMuxLoginFilter(binder: MBinder[LoginManager])
     extends Filter[SessionIdRequest, Response, SessionIdRequest, Response] {
@@ -116,7 +116,7 @@ object Keymaster {
 
   /**
    * The access issuer will use the MasterToken to gain access to service tokens
-   * @param binder Keymaster Access Service Binder
+   * @param binder It binds to the Keymaster Access Issuer using info in AccessManager
    * @param store Session store
    */
   case class KeymasterAccessIssuer(binder: MBinder[Manager], store: SessionStore)
@@ -159,7 +159,7 @@ object Keymaster {
   /**
    * This filter acquires the access and then forwards the request to upstream service
    *
-   * @param binder Upstream Service Binder
+   * @param binder It binds to the upstream service endpoint using the info passed in ServiceIdentifier
    */
   case class KeymasterAccessFilter(binder: MBinder[ServiceIdentifier])
       extends Filter[AccessIdRequest[Tokens], Response, AccessRequest[Tokens], AccessResponse[ServiceToken]] {

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
@@ -41,15 +41,18 @@ class KeymasterSpec extends BorderPatrolSuite  {
   val tokens2 = tokens.add("one", serviceToken2)
 
   // Binders
-  def mkTestManagerBinder(f: (BindRequest[Manager]) => Future[Response]): ManagerBinder = new ManagerBinder {
+  case class TestManagerBinder() extends MBinder[Manager]
+  def mkTestManagerBinder(f: (BindRequest[Manager]) => Future[Response]): TestManagerBinder = new TestManagerBinder {
     override def apply(request: BindRequest[Manager]) = f(request)
   }
-  def mkTestLoginManagerBinder(f: (BindRequest[LoginManager]) => Future[Response]): LoginManagerBinder =
-    new LoginManagerBinder {
+  case class TestLoginManagerBinder() extends MBinder[LoginManager]
+  def mkTestLoginManagerBinder(f: (BindRequest[LoginManager]) => Future[Response]): TestLoginManagerBinder =
+    new TestLoginManagerBinder {
       override def apply(request: BindRequest[LoginManager]) = f(request)
     }
-  def mkTestSidBinder(f: (BindRequest[ServiceIdentifier]) => Future[Response]): ServiceIdentifierBinder =
-    new ServiceIdentifierBinder {
+  case class TestServiceIdentifierBinder() extends MBinder[ServiceIdentifier]
+  def mkTestSidBinder(f: (BindRequest[ServiceIdentifier]) => Future[Response]): TestServiceIdentifierBinder =
+    new TestServiceIdentifierBinder {
       override def apply(request: BindRequest[ServiceIdentifier]) = f(request)
   }
 

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
@@ -1,10 +1,11 @@
 package com.lookout.borderpatrol.auth.keymaster
 
+import com.lookout.borderpatrol.Binder._
 import com.lookout.borderpatrol.auth.keymaster.Keymaster._
 import com.lookout.borderpatrol.auth._
 import com.lookout.borderpatrol.sessionx.SessionStores.MemcachedStore
 import com.lookout.borderpatrol.sessionx._
-import com.lookout.borderpatrol.{ServiceMatcher, ServiceIdentifier}
+import com.lookout.borderpatrol.{LoginManager, Manager, ServiceMatcher, ServiceIdentifier}
 import com.lookout.borderpatrol.test._
 import com.lookout.borderpatrol.util.Combinators.tap
 import com.twitter.finagle.memcached.GetResult
@@ -18,8 +19,14 @@ class KeymasterSpec extends BorderPatrolSuite  {
   import sessionx.helpers.{secretStore => store, _}
   import Tokens._
 
+  //  Managers
+  val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), "localhost:8081")
+  val keymasterAccessManager = Manager("keymaster", Path("/accessIssuer"), "localhost:8081")
+  val checkpointLoginManager = LoginManager("checkpoint", Path("/check"), "localhost:8081", Path("/loginConfirm"),
+    keymasterIdManager, keymasterAccessManager)
+
   // sids
-  val one = ServiceIdentifier("one", Path("/ent"), "enterprise", Path("/a/login"))
+  val one = ServiceIdentifier("one", "localhost:8081", Path("/ent"), "enterprise", checkpointLoginManager)
   val serviceMatcher = ServiceMatcher(Set(one))
   val sessionStore = SessionStores.InMemoryStore
 
@@ -33,8 +40,18 @@ class KeymasterSpec extends BorderPatrolSuite  {
   val tokens = Tokens(MasterToken("masterT"), serviceTokens)
   val tokens2 = tokens.add("one", serviceToken2)
 
-  // Endpoint path
-  val path = Path("/api/auth/service/v1/account_master_token")
+  // Binders
+  def mkTestManagerBinder(f: (BindRequest[Manager]) => Future[Response]): ManagerBinder = new ManagerBinder {
+    override def apply(request: BindRequest[Manager]) = f(request)
+  }
+  def mkTestLoginManagerBinder(f: (BindRequest[LoginManager]) => Future[Response]): LoginManagerBinder =
+    new LoginManagerBinder {
+      override def apply(request: BindRequest[LoginManager]) = f(request)
+    }
+  def mkTestSidBinder(f: (BindRequest[ServiceIdentifier]) => Future[Response]): ServiceIdentifierBinder =
+    new ServiceIdentifierBinder {
+      override def apply(request: BindRequest[ServiceIdentifier]) = f(request)
+  }
 
   // Method to decode SessionData from the sessionId
   def getTokensFromSessionId(sid: SessionId): Future[Tokens] =
@@ -63,25 +80,26 @@ class KeymasterSpec extends BorderPatrolSuite  {
   behavior of "KeymasterIdentityProvider"
 
   it should "succeed and return IdentityResponse with tokens received from upstream Keymaster Service" in {
-    val testService = mkTestService[Request, Response] {
-      request => tap(Response(Status.Ok))(res => {
+    val testIdentityManagerBinder = mkTestManagerBinder { request => {
+      assert(request.req.path == one.loginManager.identityManager.path.toString)
+      tap(Response(Status.Ok))(res => {
         res.contentString = TokensEncoder(tokens).toString()
         res.contentType = "application/json"
       }).toFuture
-    }
+    }}
 
     // Execute
-    val output = KeymasterIdentityProvider(testService, path)(KeymasterIdentifyReq(Credential("foo", "bar", one)))
+    val output = KeymasterIdentityProvider(testIdentityManagerBinder)(KeymasterIdentifyReq(Credential("foo", "bar", one)))
 
     // Validate
     Await.result(output).identity should be (Id(tokens))
   }
 
   it should "propagate the error Status code from Keymaster service in the IdentityProviderError exception" in {
-    val testService = mkTestService[Request, Response] { request => Response(Status.NotFound).toFuture }
+    val testIdentityManagerBinder = mkTestManagerBinder { request => Response(Status.NotFound).toFuture }
 
     // Execute
-    val output = KeymasterIdentityProvider(testService, path)(KeymasterIdentifyReq(Credential("foo", "bar", one)))
+    val output = KeymasterIdentityProvider(testIdentityManagerBinder)(KeymasterIdentifyReq(Credential("foo", "bar", one)))
 
     // Validate
     val caught = the [IdentityProviderError] thrownBy {
@@ -92,7 +110,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
   }
 
   it should "propagate the failure parsing the response from Keymaster service as an IdentityProviderError exception" in {
-    val testService = mkTestService[Request, Response] {
+    val testIdentityManagerBinder = mkTestManagerBinder {
       request => tap(Response(Status.Ok))(res => {
         res.contentString = """{"key":"data"}"""
         res.contentType = "application/json"
@@ -100,7 +118,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     }
 
     // Execute
-    val output = KeymasterIdentityProvider(testService, path)(KeymasterIdentifyReq(Credential("foo", "bar", one)))
+    val output = KeymasterIdentityProvider(testIdentityManagerBinder)(KeymasterIdentifyReq(Credential("foo", "bar", one)))
 
     // Validate
     val caught = the [IdentityProviderError] thrownBy {
@@ -204,30 +222,31 @@ class KeymasterSpec extends BorderPatrolSuite  {
   behavior of "KeymasterAccessIssuer"
 
   it should "succeed, return service token found in the ServiceTokens cache" in {
-    val testService = mkTestService[Request, Response] {
+    val testAccessManagerBinder = mkTestManagerBinder {
       request => { assert(false); Response(Status.Ok).toFuture }
     }
     val sessionId = sessionid.next
 
     // Execute
-    val output = KeymasterAccessIssuer(testService, path, sessionStore)(KeymasterAccessReq(Id(tokens2), one, sessionId))
+    val output = KeymasterAccessIssuer(testAccessManagerBinder, sessionStore)(KeymasterAccessReq(Id(tokens2), one, sessionId))
 
     // Validate
     Await.result(output).access.access should be (serviceToken2)
   }
 
   it should "succeed, save in SessionStore and return the ServiceToken received from the Keymaster Service" in {
-    val testService = mkTestService[Request, Response] {
-      request => tap(Response(Status.Ok))(res => {
+    val testAccessManagerBinder = mkTestManagerBinder { request => {
+      assert(request.req.path == one.loginManager.accessManager.path.toString)
+      tap(Response(Status.Ok))(res => {
         res.contentString = TokensEncoder(tokens2).toString()
         res.contentType = "application/json"
       }).toFuture
-    }
+    }}
     val sessionId = sessionid.next
     sessionStore.update[Tokens](Session(sessionId, tokens))
 
     // Execute
-    val output = KeymasterAccessIssuer(testService, path, sessionStore)(KeymasterAccessReq(Id(tokens), one, sessionId))
+    val output = KeymasterAccessIssuer(testAccessManagerBinder, sessionStore)(KeymasterAccessReq(Id(tokens), one, sessionId))
 
     // Validate
     Await.result(output).access.access should be (serviceToken2)
@@ -236,11 +255,11 @@ class KeymasterSpec extends BorderPatrolSuite  {
   }
 
   it should "propagate the error Status code returned by the Keymaster service, as the AccessIssuerError exception" in {
-    val testService = mkTestService[Request, Response] { request => Response(Status.NotFound).toFuture }
+    val testAccessManagerBinder = mkTestManagerBinder { request => Response(Status.NotFound).toFuture }
     val sessionId = sessionid.next
 
     // Execute
-    val output = KeymasterAccessIssuer(testService, path, sessionStore)(KeymasterAccessReq(Id(tokens), one, sessionId))
+    val output = KeymasterAccessIssuer(testAccessManagerBinder, sessionStore)(KeymasterAccessReq(Id(tokens), one, sessionId))
 
     // Validate
     val caught = the [AccessIssuerError] thrownBy {
@@ -251,7 +270,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
   }
 
   it should "propagate the failure to parse response content from Keymaster service, as AccessIssuerError exception" in {
-    val testService = mkTestService[Request, Response] {
+    val testAccessManagerBinder = mkTestManagerBinder {
       request => tap(Response(Status.Ok))(res => {
         res.contentString = "invalid string"
         res.contentType = "application/json"
@@ -260,7 +279,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val sessionId = sessionid.next
 
     // Execute
-    val output = KeymasterAccessIssuer(testService, path, sessionStore)(KeymasterAccessReq(Id(tokens), one, sessionId))
+    val output = KeymasterAccessIssuer(testAccessManagerBinder, sessionStore)(KeymasterAccessReq(Id(tokens), one, sessionId))
 
     // Validate
     val caught = the [AccessIssuerError] thrownBy {
@@ -270,7 +289,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
   }
 
   it should "return an AccessDenied exception, if it fails to find the ServiceToken in the Keymaster response" in {
-    val testService = mkTestService[Request, Response] {
+    val testAccessManagerBinder = mkTestManagerBinder {
       request => tap(Response(Status.Ok))(res => {
         res.contentString = TokensEncoder(tokens).toString()
         res.contentType = "application/json"
@@ -279,7 +298,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val sessionId = sessionid.next
 
     // Execute
-    val output = KeymasterAccessIssuer(testService, path, sessionStore)(KeymasterAccessReq(Id(tokens), one, sessionId))
+    val output = KeymasterAccessIssuer(testAccessManagerBinder, sessionStore)(KeymasterAccessReq(Id(tokens), one, sessionId))
 
     // Validate
     val caught = the [AccessDenied] thrownBy {
@@ -295,10 +314,10 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val accessService = mkTestService[AccessRequest[Tokens], AccessResponse[ServiceToken]] {
       request => KeymasterAccessRes(Access(serviceToken2)).toFuture
     }
-    val upstreamService = mkTestService[Request, Response] {
+    val testSidBinder = mkTestSidBinder {
       request => {
         // Verify service token in the request
-        assert (request.headerMap.get("Auth-Token") == Some(serviceToken2.value))
+        assert (request.req.headerMap.get("Auth-Token") == Some(serviceToken2.value))
         Response(Status.Ok).toFuture
       }
     }
@@ -310,7 +329,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val request = req("enterprise", "/dang")
 
     // Execute
-    val output = (KeymasterAccessFilter(upstreamService) andThen accessService)(
+    val output = (KeymasterAccessFilter(testSidBinder) andThen accessService)(
       AccessIdRequest(SessionIdRequest(ServiceRequest(request, one), sessionId), Id(tokens)))
 
     // Validate
@@ -321,10 +340,10 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val accessService = mkTestService[AccessRequest[Tokens], AccessResponse[ServiceToken]] {
       request => KeymasterAccessRes(Access(serviceToken2)).toFuture
     }
-    val upstreamService = mkTestService[Request, Response] {
+    val testSidBinder = mkTestSidBinder {
       request => {
         // Verify service token in the request
-        assert (request.headerMap.get("Auth-Token") == Some(serviceToken2.value))
+        assert (request.req.headerMap.get("Auth-Token") == Some(serviceToken2.value))
         Response(Status.NotFound).toFuture
       }
     }
@@ -336,7 +355,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val request = req("enterprise", "/dang")
 
     // Execute
-    val output = (KeymasterAccessFilter(upstreamService) andThen accessService)(
+    val output = (KeymasterAccessFilter(testSidBinder) andThen accessService)(
       AccessIdRequest(SessionIdRequest(ServiceRequest(request, one), sessionId), Id(tokens)))
 
     // Validate
@@ -347,10 +366,10 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val accessService = mkTestService[AccessRequest[Tokens], AccessResponse[ServiceToken]] {
       request => Future.exception(new Exception("Oopsie"))
     }
-    val upstreamService = mkTestService[Request, Response] {
+    val testSidBinder = mkTestSidBinder {
       request => {
         // Verify service token in the request
-        assert (request.headerMap.get("Auth-Token") == Some(serviceToken2.value))
+        assert (request.req.headerMap.get("Auth-Token") == Some(serviceToken2.value))
         Response(Status.NotFound).toFuture
       }
     }
@@ -362,7 +381,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val request = req("enterprise", "/dang")
 
     // Execute
-    val output = (KeymasterAccessFilter(upstreamService) andThen accessService)(
+    val output = (KeymasterAccessFilter(testSidBinder) andThen accessService)(
       AccessIdRequest(SessionIdRequest(ServiceRequest(request, one), sessionId), Id(tokens)))
 
     // Validate
@@ -375,7 +394,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
   it should "succeed and invoke the GET on keymaster service" in {
     val testService = mkTestService[SessionIdRequest, Response] { _ => fail("Should not get here") }
-    val keymasterService = mkTestService[Request, Response] { _ => Response(Status.Ok).toFuture }
+    val testLoginManagerBinder = mkTestLoginManagerBinder { _ => Response(Status.Ok).toFuture }
 
     // Allocate and Session
     val sessionId = sessionid.next
@@ -384,7 +403,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val request = Request(Method.Get, "/ent")
 
     // Execute
-    val output = (KeymasterMethodMuxLoginFilter(keymasterService, path) andThen testService)(
+    val output = (KeymasterMethodMuxLoginFilter(testLoginManagerBinder) andThen testService)(
       SessionIdRequest(ServiceRequest(request, one), sessionId))
 
     // Validate
@@ -393,7 +412,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
   it should "succeed and invoke the POST on upstream service" in {
     val testService = mkTestService[SessionIdRequest, Response] { _ => Response(Status.Ok).toFuture }
-    val keymasterService = mkTestService[Request, Response] { _ => fail("Should not get here") }
+    val testLoginManagerBinder = mkTestLoginManagerBinder { _ => fail("Should not get here") }
 
     // Allocate and Session
     val sessionId = sessionid.next
@@ -402,7 +421,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val request = Request(Method.Post, "/ent")
 
     // Execute
-    val output = (KeymasterMethodMuxLoginFilter(keymasterService, path) andThen testService)(
+    val output = (KeymasterMethodMuxLoginFilter(testLoginManagerBinder) andThen testService)(
       SessionIdRequest(ServiceRequest(request, one), sessionId))
 
     // Validate
@@ -411,7 +430,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
   it should "succeed and invoke the non GET or POST method on keymaster service" in {
     val testService = mkTestService[SessionIdRequest, Response] { _ => fail("Should not get here") }
-    val keymasterService = mkTestService[Request, Response] { _ => Response(Status.Ok).toFuture }
+    val testLoginManagerBinder = mkTestLoginManagerBinder { _ => Response(Status.Ok).toFuture }
 
     // Allocate and Session
     val sessionId = sessionid.next
@@ -420,10 +439,109 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val request = Request(Method.Head, "/ent")
 
     // Execute
-    val output = (KeymasterMethodMuxLoginFilter(keymasterService, path) andThen testService)(
+    val output = (KeymasterMethodMuxLoginFilter(testLoginManagerBinder) andThen testService)(
       SessionIdRequest(ServiceRequest(request, one), sessionId))
 
     // Validate
     Await.result(output).status should be (Status.Ok)
+  }
+
+  behavior of "keymasterIdentityProviderChain"
+
+  it should "succeed and invoke the GET on loginManager" in {
+    val server = com.twitter.finagle.Httpx.serve(
+      "localhost:8081", mkTestService[Request, Response]{request =>
+        if (request.path.contains(checkpointLoginManager.path.toString)) Response(Status.Ok).toFuture
+        else Response(Status.BadRequest).toFuture
+      })
+
+    try {
+      // Allocate and Session
+      val sessionId = sessionid.next
+
+      // Login manager request
+      val loginRequest = req("enterprise", checkpointLoginManager.path.toString,
+        ("username" -> "foo"), ("password" -> "bar"))
+
+      // Original request
+      val origReq = req("enterprise", "/ent", ("fake" -> "drake"))
+      sessionStore.update[Request](Session(sessionId, origReq))
+
+      // Execute
+      val output = (keymasterIdentityProviderChain(sessionStore)(store))(
+        SessionIdRequest(ServiceRequest(loginRequest, one), sessionId))
+
+      // Validate
+      Await.result(output).status should be(Status.Ok)
+    } finally {
+      server.close()
+    }
+  }
+
+  it should "succeed and invoke the GET on identityManager" in {
+    val server = com.twitter.finagle.Httpx.serve(
+      "localhost:8081", mkTestService[Request, Response]{request =>
+        if (request.path.contains(keymasterIdManager.path.toString))
+          tap(Response(Status.Ok))(res => {
+            res.contentString = TokensEncoder(tokens).toString()
+            res.contentType = "application/json"
+          }).toFuture
+        else Response(Status.BadRequest).toFuture
+      })
+
+    try {
+      // Allocate and Session
+      val sessionId = sessionid.next
+
+      // Login manager request
+      val loginRequest = Request(Method.Post, Request.queryString(checkpointLoginManager.loginPath.toString,
+        ("username" -> "foo"), ("password" -> "bar")))
+
+      // Original request
+      val origReq = req("enterprise", "/ent", ("fake" -> "drake"))
+      sessionStore.update[Request](Session(sessionId, origReq))
+
+      // Execute
+      val output = (keymasterIdentityProviderChain(sessionStore)(store))(
+        SessionIdRequest(ServiceRequest(loginRequest, one), sessionId))
+
+      // Validate
+      Await.result(output).status should be(Status.Found)
+    } finally {
+      server.close()
+    }
+  }
+
+  behavior of "keymasterAccessIssuerChain"
+
+  it should "succeed and invoke the GET on accessManager" in {
+    val server = com.twitter.finagle.Httpx.serve(
+      "localhost:8081", mkTestService[Request, Response]{request =>
+        if (request.path.contains(keymasterAccessManager.path.toString))
+          tap(Response(Status.Ok))(res => {
+            res.contentString = TokensEncoder(tokens2).toString()
+            res.contentType = "application/json"
+          }).toFuture
+        else if (request.path.contains(one.path.toString)) Response(Status.Ok).toFuture
+        else Response(Status.BadRequest).toFuture
+      })
+
+    try {
+      // Allocate and Session
+      val sessionId = sessionid.next
+
+      // Original request
+      val origReq = req("enterprise", "/ent")
+      sessionStore.update[Tokens](Session(sessionId, tokens))
+
+      // Execute
+      val output = (keymasterAccessIssuerChain(sessionStore)(store))(
+        SessionIdRequest(ServiceRequest(origReq, one), sessionId))
+
+      // Validate
+      Await.result(output).status should be(Status.Ok)
+    } finally {
+      server.close()
+    }
   }
 }

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
@@ -20,13 +20,13 @@ class KeymasterSpec extends BorderPatrolSuite  {
   import Tokens._
 
   //  Managers
-  val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), "localhost:8081")
-  val keymasterAccessManager = Manager("keymaster", Path("/accessIssuer"), "localhost:8081")
-  val checkpointLoginManager = LoginManager("checkpoint", Path("/check"), "localhost:8081", Path("/loginConfirm"),
+  val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), "localhost:5678")
+  val keymasterAccessManager = Manager("keymaster", Path("/accessIssuer"), "localhost:5678")
+  val checkpointLoginManager = LoginManager("checkpoint", Path("/check"), "localhost:5678", Path("/loginConfirm"),
     keymasterIdManager, keymasterAccessManager)
 
   // sids
-  val one = ServiceIdentifier("one", "localhost:8081", Path("/ent"), "enterprise", checkpointLoginManager)
+  val one = ServiceIdentifier("one", "localhost:5678", Path("/ent"), "enterprise", checkpointLoginManager)
   val serviceMatcher = ServiceMatcher(Set(one))
   val sessionStore = SessionStores.InMemoryStore
 
@@ -453,7 +453,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
   it should "succeed and invoke the GET on loginManager" in {
     val server = com.twitter.finagle.Httpx.serve(
-      "localhost:8081", mkTestService[Request, Response]{request =>
+      "localhost:5678", mkTestService[Request, Response]{request =>
         if (request.path.contains(checkpointLoginManager.path.toString)) Response(Status.Ok).toFuture
         else Response(Status.BadRequest).toFuture
       })
@@ -483,7 +483,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
   it should "succeed and invoke the GET on identityManager" in {
     val server = com.twitter.finagle.Httpx.serve(
-      "localhost:8081", mkTestService[Request, Response]{request =>
+      "localhost:5678", mkTestService[Request, Response]{request =>
         if (request.path.contains(keymasterIdManager.path.toString))
           tap(Response(Status.Ok))(res => {
             res.contentString = TokensEncoder(tokens).toString()
@@ -519,7 +519,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
   it should "succeed and invoke the GET on accessManager" in {
     val server = com.twitter.finagle.Httpx.serve(
-      "localhost:8081", mkTestService[Request, Response]{request =>
+      "localhost:5678", mkTestService[Request, Response]{request =>
         if (request.path.contains(keymasterAccessManager.path.toString))
           tap(Response(Status.Ok))(res => {
             res.contentString = TokensEncoder(tokens2).toString()

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/TokensSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/TokensSpec.scala
@@ -22,13 +22,6 @@ class TokensSpec extends BorderPatrolSuite  {
     serviceTokens.find("service2") should be equals (serviceToken2)
   }
 
-  it should "uphold encoding/decoding ServiceTokens" in {
-    def encodeDecode(tokens: ServiceTokens) : ServiceTokens = {
-      ServiceTokensDecoder.decodeJson(ServiceTokensEncoder(tokens)).fold[ServiceTokens](e => ServiceTokens(), t => t)
-    }
-    encodeDecode(serviceTokens) should be (serviceTokens)
-  }
-
   behavior of "Tokens"
 
   it should "be able to find the ServiceToken by service name" in {

--- a/bpConfig.json
+++ b/bpConfig.json
@@ -41,7 +41,7 @@
       "hosts": "localhost:8081",
       "loginManager": "checkpoint",
       "subdomain": "admin",
-      "path": "/admin/metrics.json",
+      "path": "/admin",
       "name": "admin"
     }
   ]

--- a/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
@@ -36,12 +36,12 @@ object Binder {
    * @tparam A
    */
   abstract class MBinder[A: BinderContext](cache: mutable.Map[String, Service[Request, Response]] =
-                                       mutable.Map.empty[String, Service[Request, Response]])
-    extends Service[BindRequest[A], Response] {
+                                           mutable.Map.empty[String, Service[Request, Response]])
+      extends Service[BindRequest[A], Response] {
     def apply(req: BindRequest[A]): Future[Response] = {
-      cache.getOrElse(req.name,
+      this.synchronized(cache.getOrElse(req.name,
         util.Combinators.tap(Httpx.newService(req.hosts))(cli => cache(req.name) = cli)
-      ).apply(req.req)
+      )).apply(req.req)
     }
     def get(name: String): Option[Service[Request, Response]] = cache.get(name)
   }

--- a/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
@@ -5,6 +5,9 @@ import com.twitter.finagle.httpx.{Response, Request}
 import com.twitter.util.Future
 import scala.collection.mutable
 
+/**
+ * Binder object defines methods and shells used to bind to upstream endpoints
+ */
 object Binder {
 
   /**

--- a/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
@@ -1,0 +1,67 @@
+package com.lookout.borderpatrol
+
+import com.twitter.finagle.{Httpx, Service}
+import com.twitter.finagle.httpx.{Response, Request}
+import com.twitter.util.Future
+import scala.collection.mutable
+
+object Binder {
+
+  /**
+   * trait for the context binding
+   * @tparam A
+   */
+  trait BinderContext[A] {
+    def name(manager: A): String
+    def hosts(manager: A): String
+  }
+
+  /**
+   * Bind request pod
+   */
+  case class BindRequest[A](context: A, req: Request)
+
+  /**
+   * It enables dynamic binding to the endpoints (e.g. login service, identity service, etc)
+   *
+   * Note that BinderContext makes it possible to templatize this code for all the LoginManagerBinder, ManagerBinder,
+   * ServiceIdentigfierBinder, etc, by making calls to methods (e.g. name & hosts) visible in the template.
+   *
+   * @param cache Caches the already established client service
+   * @tparam A
+   */
+  abstract class MBinder[A: BinderContext](cache: mutable.Map[String, Service[Request, Response]] =
+                                       mutable.Map.empty[String, Service[Request, Response]])
+    extends Service[BindRequest[A], Response] {
+    def apply(req: BindRequest[A]): Future[Response] = {
+      cache.getOrElse(implicitly[BinderContext[A]].name(req.context),
+        util.Combinators.tap(Httpx.newService(implicitly[BinderContext[A]].hosts(req.context)))(cli =>
+          cache(implicitly[BinderContext[A]].name(req.context)) = cli)
+      ).apply(req.req)
+    }
+    def get(name: String): Option[Service[Request, Response]] = cache.get(name)
+  }
+
+  /**
+   * implicit values for evidence parameter of type BinderContext
+   */
+  implicit object LoginManagerBinderContext extends BinderContext[LoginManager] {
+    def name(lm: LoginManager): String = lm.name
+    def hosts(lm: LoginManager): String = lm.hosts
+  }
+  implicit object ManagerBinderContext extends BinderContext[Manager] {
+    def name(m: Manager): String = m.name
+    def hosts(m: Manager): String = m.hosts
+  }
+  implicit object ServiceIdentifierBinderContext extends BinderContext[ServiceIdentifier] {
+    def name(sid: ServiceIdentifier): String = sid.name
+    def hosts(sid: ServiceIdentifier): String = sid.hosts
+  }
+
+  /**
+   * Binder objects
+   */
+  case class LoginManagerBinder() extends MBinder[LoginManager]
+  case class ManagerBinder() extends MBinder[Manager]
+  case class ServiceIdentifierBinder() extends MBinder[ServiceIdentifier]
+}

--- a/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
@@ -1,0 +1,23 @@
+package com.lookout.borderpatrol
+
+import com.twitter.finagle.httpx.path.Path
+
+/**
+ *
+ * @param name
+ * @param path
+ * @param hosts
+ */
+case class Manager(name: String, path: Path, hosts: String)
+
+/**
+ *
+ * @param name
+ * @param path
+ * @param hosts
+ * @param loginPath
+ * @param identityManager
+ * @param accessManager
+ */
+case class LoginManager(name: String, path: Path, hosts: String,
+                        loginPath: Path, identityManager: Manager, accessManager: Manager)

--- a/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
@@ -9,6 +9,6 @@ import com.twitter.finagle.httpx.path.Path
  * @param name The name that can be used to refer to a [[com.twitter.finagle.Name]]
  * @param path The external url path prefix that routes to the internal service
  * @param subdomain A default fall-back when path is only `/`
- * @param login The location to send a user when a request to this service is Unauthorized
+ * @param loginManager The location to send a user when a request to this service is Unauthorized
  */
-case class ServiceIdentifier(name: String, path: Path, subdomain: String, login: Path)
+case class ServiceIdentifier(name: String, hosts: String, path: Path, subdomain: String, loginManager: LoginManager)

--- a/core/src/main/scala/com/lookout/borderpatrol/ServiceMatcher.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/ServiceMatcher.scala
@@ -43,9 +43,7 @@ case class ServiceMatcher(services: Set[ServiceIdentifier]) {
    * @param cmp A comparable function
    * @return The maximuma of folding over the set with the cmp function
    */
-  private[this] def foldWith[A](sis: Set[A],
-                             cmp: (A, A) => A):
-      Option[A] =
+  private[this] def foldWith[A](sis: Set[A], cmp: (A, A) => A): Option[A] =
     sis.foldRight(Option.empty[A])((lhs, res) => res match {
       case Some(rhs) => Some(cmp(lhs, rhs))
       case None => Some(lhs)
@@ -78,6 +76,5 @@ case class ServiceMatcher(services: Set[ServiceIdentifier]) {
       val pathSet = Set(sid.path, sid.loginManager.path, sid.loginManager.loginPath)
       !pathSet.filter(Path(req.path).startsWith(_)).isEmpty
     })
-
 }
 

--- a/core/src/main/scala/com/lookout/borderpatrol/ServiceMatcher.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/ServiceMatcher.scala
@@ -43,10 +43,10 @@ case class ServiceMatcher(services: Set[ServiceIdentifier]) {
    * @param cmp A comparable function
    * @return The maximuma of folding over the set with the cmp function
    */
-  private[this] def foldWith(sis: Set[ServiceIdentifier],
-                             cmp: (ServiceIdentifier, ServiceIdentifier) => ServiceIdentifier):
-      Option[ServiceIdentifier] =
-    sis.foldRight(Option.empty[ServiceIdentifier])((lhs, res) => res match {
+  private[this] def foldWith[A](sis: Set[A],
+                             cmp: (A, A) => A):
+      Option[A] =
+    sis.foldRight(Option.empty[A])((lhs, res) => res match {
       case Some(rhs) => Some(cmp(lhs, rhs))
       case None => Some(lhs)
     })
@@ -65,44 +65,19 @@ case class ServiceMatcher(services: Set[ServiceIdentifier]) {
    * @return the service name from the longest matching subdomain
    */
   def subdomain(host: String): Option[ServiceIdentifier] =
-    foldWith(
+    foldWith[ServiceIdentifier](
       services.filter(si => host.startsWith(si.subdomain + domainTerm)),
       (si1, si2) => if (si1.subdomain.size > si2.subdomain.size) si1 else si2
-    )
-
-  /**
-   * Find the longest matching path in the request
-   *
-   * @example
-   *          Given a request of path of "/a" and a set of paths Set("/account", "/a")
-   * @param path path from request
-   * @return the service name from the longest matching path
-   */
-  def path(path: Path): Option[ServiceIdentifier] =
-    foldWith(
-      services.filter(id => path.startsWith(id.path)),
-      (si1, si2) => if (si1.path.toString.size > si2.path.toString.size) si1 else si2
-    )
-
-  /**
-   * Find the longest matching login path in the request
-   *
-   * @example
-   *          Given a request of path of "/a" and a set of paths Set("/account", "/a")
-   * @param path path from request
-   * @return the service name from the longest matching path
-   */
-  def login(path: Path): Option[ServiceIdentifier] =
-    foldWith(
-      services.filter(id => path.startsWith(id.login)),
-      (si1, si2) => if (si1.login.toString.size > si2.login.toString.size) si1 else si2
     )
 
   /**
    * Derive a ServiceIdentifier from an `httpx.Request`
    */
   def get(req: Request): Option[ServiceIdentifier] =
-    path(Path(req.path)) orElse login(Path(req.path))  orElse req.host.flatMap(subdomain)
+    req.host.flatMap(subdomain).filter(sid => {
+      val pathSet = Set(sid.path, sid.loginManager.path, sid.loginManager.loginPath)
+      !pathSet.filter(Path(req.path).startsWith(_)).isEmpty
+    })
 
 }
 

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
@@ -54,7 +54,7 @@ case class SessionIdFilter(store: SessionStore)(implicit secretStore: SecretStor
           session <- Session(req.req)
           _ <- store.update(session)
         } yield tap(Response(Status.Found)) { res =>
-          res.location = req.serviceId.login.toString
+          res.location = req.serviceId.loginManager.path.toString
           res.addCookie(session.id.asCookie)
         }
     }
@@ -81,7 +81,7 @@ class IdentityFilter[A : SessionDataEncoder](store: SessionStore)(implicit secre
         s <- Session(req.req.req)
         _ <- store.update(s)
       } yield tap(Response(Status.Found)) { res =>
-          res.location = req.req.serviceId.login.toString // set to login url
+          res.location = req.req.serviceId.loginManager.path.toString // set to login url
           res.addCookie(s.id.asCookie) // add SessionId value as a Cookie
         }
     })

--- a/core/src/main/scala/com/lookout/borderpatrol/crypto/Signer.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/crypto/Signer.scala
@@ -12,12 +12,13 @@ import com.lookout.borderpatrol.util.Combinators.tap
 trait Signer {
   val algo: String
   val key: Key
-  lazy val hmac: Mac = tap(Mac.getInstance(algo))(mac => mac.init(key))
 
+  /**
+   * Sign the input bytes using configured algorithm
+   * @param bytes
+   * @return Signature
+   */
   def sign(bytes: IndexedSeq[Byte]): Signature =
-    /* java.crypto.Mac is NOT threadsafe, hence use synchronized block */
-    this.synchronized {
-      hmac.doFinal(bytes.toArray).toIndexedSeq
-    }
+    tap(Mac.getInstance(algo))(mac => mac.init(key)).doFinal(bytes.toArray).toIndexedSeq
 }
 

--- a/core/src/main/scala/com/lookout/borderpatrol/crypto/Signer.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/crypto/Signer.scala
@@ -15,6 +15,9 @@ trait Signer {
   lazy val hmac: Mac = tap(Mac.getInstance(algo))(mac => mac.init(key))
 
   def sign(bytes: IndexedSeq[Byte]): Signature =
-    hmac.doFinal(bytes.toArray).toIndexedSeq
+    /* java.crypto.Mac is NOT threadsafe, hence use synchronized block */
+    this.synchronized {
+      hmac.doFinal(bytes.toArray).toIndexedSeq
+    }
 }
 

--- a/core/src/test/scala/com/lookout/borderpatrol/test/BinderSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/BinderSpec.scala
@@ -1,0 +1,38 @@
+package com.lookout.borderpatrol.test
+
+import com.lookout.borderpatrol._
+import com.lookout.borderpatrol.Binder._
+import com.lookout.borderpatrol.{LoginManager, Manager, ServiceIdentifier, ServiceMatcher}
+import com.twitter.finagle.Service
+import com.twitter.finagle.httpx.{Status, Response, RequestBuilder, Request}
+import com.twitter.finagle.httpx.path.Path
+import com.twitter.util.{Await, Future}
+
+class BinderSpec extends BorderPatrolSuite {
+  val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), "localhost:8081")
+
+  // Request helper
+  def req(path: String): Request =
+    Request(s"http://localhost${path.toString}")
+
+  def mkTestService[A](f: (A) => Future[Response]) : Service[A, Response] = new Service[A, Response] {
+    def apply(request: A) = f(request)
+  }
+
+  behavior of "ManagerBinder"
+
+  it should "successfully connect to server and returns the response" in {
+    val managerBinder = ManagerBinder()
+    val server = com.twitter.finagle.Httpx.serve(
+      "localhost:8081", mkTestService[Request]{_ => Response(Status.NotAcceptable).toFuture })
+    try {
+      val bindReq = BindRequest[Manager](keymasterIdManager, req(keymasterIdManager.path.toString))
+      val output = managerBinder(bindReq)
+      Await.result(output).status should be(Status.NotAcceptable)
+      /* Make sure client is cached in the cache */
+      managerBinder.get(keymasterIdManager.name) should not be None
+    } finally {
+      server.close()
+    }
+  }
+}

--- a/core/src/test/scala/com/lookout/borderpatrol/test/BinderSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/BinderSpec.scala
@@ -2,9 +2,8 @@ package com.lookout.borderpatrol.test
 
 import com.lookout.borderpatrol._
 import com.lookout.borderpatrol.Binder._
-import com.lookout.borderpatrol.{LoginManager, Manager, ServiceIdentifier, ServiceMatcher}
 import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.{Status, Response, RequestBuilder, Request}
+import com.twitter.finagle.httpx.{Status, Response, Request}
 import com.twitter.finagle.httpx.path.Path
 import com.twitter.util.{Await, Future}
 
@@ -22,15 +21,14 @@ class BinderSpec extends BorderPatrolSuite {
   behavior of "ManagerBinder"
 
   it should "successfully connect to server and returns the response" in {
-    val managerBinder = ManagerBinder()
     val server = com.twitter.finagle.Httpx.serve(
       "localhost:8081", mkTestService[Request]{_ => Response(Status.NotAcceptable).toFuture })
     try {
       val bindReq = BindRequest[Manager](keymasterIdManager, req(keymasterIdManager.path.toString))
-      val output = managerBinder(bindReq)
+      val output = ManagerBinder(bindReq)
       Await.result(output).status should be(Status.NotAcceptable)
       /* Make sure client is cached in the cache */
-      managerBinder.get(keymasterIdManager.name) should not be None
+      ManagerBinder.get(keymasterIdManager.name) should not be None
     } finally {
       server.close()
     }

--- a/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
@@ -1,7 +1,6 @@
 package com.lookout.borderpatrol.example
 
-import com.twitter.finagle.httpx.{Response, Request}
-import com.twitter.finagle.{Service, Httpx}
+import com.twitter.finagle.Httpx
 import com.twitter.server.TwitterServer
 import com.twitter.util.Await
 

--- a/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
@@ -12,7 +12,6 @@ object BorderPatrolApp extends TwitterServer with Config {
 
   premain {
     implicit val serverConfig = readServerConfig(configFile())
-    implicit val loginManagerMap: Map[String, Service[Request, Response]] = Map.empty[String, Service[Request, Response]]
 
     val server1 = Httpx.serve(":8080", MainServiceChain)
     val server2 = Httpx.serve(":8081", getMockRoutingService)

--- a/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
@@ -1,16 +1,20 @@
 package com.lookout.borderpatrol.example
 
-import com.twitter.finagle.Httpx
+import com.twitter.finagle.httpx.{Response, Request}
+import com.twitter.finagle.{Service, Httpx}
 import com.twitter.server.TwitterServer
 import com.twitter.util.Await
 
 object BorderPatrolApp extends TwitterServer with Config {
   import service._
+  import MockService._
+  import Config._
 
   premain {
-    implicit val serverConfig = ServerConfig(secretStore(), sessionStore(), serviceIds())
+    implicit val serverConfig = readServerConfig(configFile())
+    implicit val loginManagerMap: Map[String, Service[Request, Response]] = Map.empty[String, Service[Request, Response]]
 
-    val server1 = Httpx.serve(":8080", getRoutingService)
+    val server1 = Httpx.serve(":8080", MainServiceChain)
     val server2 = Httpx.serve(":8081", getMockRoutingService)
     Await.all(server1, server2)
   }

--- a/example/src/main/scala/com/lookout/borderpatrol/example/Config.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/Config.scala
@@ -49,7 +49,7 @@ case class ServerConfig(secretStore: SecretStoreApi,
  */
 object Config {
 
-  val defaultConfigFile = "serviceids.json"
+  val defaultConfigFile = "bpConfig.json"
   val defaultSecretStore = SecretStores.InMemorySecretStore(Secrets(Secret(), Secret()))
   val defaultSessionStore = SessionStores.InMemoryStore
   val defaultServiceIdsFile = "bpConfig.json"

--- a/example/src/main/scala/com/lookout/borderpatrol/example/Config.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/Config.scala
@@ -1,75 +1,204 @@
 package com.lookout.borderpatrol.example
 
-import com.lookout.borderpatrol.ServiceIdentifier
+import com.lookout.borderpatrol.{Manager, LoginManager, ServiceIdentifier}
 import com.lookout.borderpatrol.sessionx.SecretStores.InMemorySecretStore
-import com.lookout.borderpatrol.sessionx.SessionStores.{MemcachedStore, InMemoryStore}
+import com.lookout.borderpatrol.sessionx.SessionStores.MemcachedStore
+import com.lookout.borderpatrol.sessionx.SessionStores.InMemoryStore
 import com.lookout.borderpatrol.sessionx._
 import com.twitter.finagle.MemcachedClient
-import com.twitter.finagle.httpx.Method
 import com.twitter.finagle.httpx.path.Path
-import com.twitter.app.{Flaggable, App}
+import com.twitter.app.App
 import cats.data.Xor
 import io.circe.{Encoder, _}
 import io.circe.jawn._
-import io.circe.generic.auto._ // DO NOT REMOVE
+import io.circe.generic.auto._
+import io.circe.syntax._
 import scala.io.Source
 
 
-case class ServerConfig(secretStore: SecretStoreApi,
-                        sessionStore: SessionStore,
-                        serviceIdentifiers: Set[ServiceIdentifier])
-
 // scalastyle:off null
-class ConfigError(val message: String) extends Exception(message, null)
+case class ConfigError(message: String)
+  extends Exception(s"An error occurred while reading BorderPatrol Configuration: ${message}", null)
+
+case class DuplicateConfigError(key: String, field: String)
+  extends Exception("An error occurred while reading BorderPatrol Configuration: " +
+    s"Duplicate entries for key(s) (${key}) - are found in the field: ${field}")
+
+case class InvalidConfigError(message: String)
+  extends Exception(message, null)
+
+case class ServerConfig(secretStore: SecretStoreApi,
+                   sessionStore: SessionStore,
+                   serviceIdentifiers: Set[ServiceIdentifier],
+                   loginManagers: Set[LoginManager],
+                   identityManagers: Set[Manager],
+                   accessManagers: Set[Manager]) {
+
+  def findIdentityManager(n: String): Manager = identityManagers.find(_.name == n)
+    .getOrElse(throw new InvalidConfigError("Failed to find IdentityManager for: " + n))
+
+  def findAccessManager(n: String): Manager = accessManagers.find(_.name == n)
+    .getOrElse(throw new InvalidConfigError("Failed to find Manager for: " + n))
+
+  def findLoginManager(n: String): LoginManager = loginManagers.find(_.name == n)
+    .getOrElse(throw new InvalidConfigError("Failed to find LoginManager for: " + n))
+}
 
 /**
  * Where you will find the Secret Store and Session Store
  */
 object Config {
 
+  val defaultConfigFile = "serviceids.json"
   val defaultSecretStore = SecretStores.InMemorySecretStore(Secrets(Secret(), Secret()))
   val defaultSessionStore = SessionStores.InMemoryStore
-  val defaultServiceIdsFile = "serviceids.json"
+  val defaultServiceIdsFile = "bpConfig.json"
+  val serverConfigFields = Set("secretStore", "sessionStore", "serviceIdentifiers", "loginManagers",
+    "identityManagers", "accessManager")
 
-  // Flaggable for Secret Store
-  implicit val secretStoreApiFlaggable = new Flaggable[SecretStoreApi] {
-    def parse (s: String): SecretStoreApi = {
-      throw new ConfigError("Invalid Secret Store configuration")
-    }
-    override def show(t: SecretStoreApi) = t match {
-      case InMemorySecretStore(_) => "In Memory Secret Store"
-      case a => a.getClass.getSimpleName
+  // Encoder/Decoder for Path
+  implicit val encodePath: Encoder[Path] = Encoder[String].contramap(_.toString)
+  implicit val decodePath: Decoder[Path] = Decoder[String].map(Path(_))
+
+  // Encoder/Decoder for SessionStore
+  implicit val encodeSessionStore: Encoder[SessionStore] = Encoder.instance {
+    case x: InMemoryStore.type => Json.obj(("type", Json.string(x.getClass.getSimpleName)))
+    case y: MemcachedStore =>  Json.obj(("type", Json.string(y.getClass.getSimpleName)),
+      ("hosts", Json.string("localhost:123")))
+    case other => Json.string("Error: " + other.toString)
+  }
+  implicit val decodeSessionStore: Decoder[SessionStore] = Decoder.instance { c =>
+    c.downField("type").as[String].flatMap {
+      case "InMemoryStore$" => Xor.right(defaultSessionStore)
+      case "MemcachedStore"   => c.downField("hosts").as[String].map(hosts =>
+        SessionStores.MemcachedStore(MemcachedClient.newRichClient(hosts)))
+      case other  => Xor.left(DecodingFailure(s"Invalid sessionStore: $other", c.history))
     }
   }
 
-  // Flaggable for Session Store
-  implicit val sessionStoreApiFlaggable = new Flaggable[SessionStore] {
-    def parse (s: String): SessionStore =
-      SessionStores.MemcachedStore(MemcachedClient.newRichClient(s))
-
-    override def show(t: SessionStore) = t match {
-      case InMemoryStore => "In Memory Session Store"
-      case MemcachedStore(_) => "Memcached Session Store"
-      case a => a.getClass.getSimpleName
+  // Encoder/Decoder for SecretStore
+  implicit val encodeSecretStore: Encoder[SecretStoreApi] = Encoder.instance {
+    case x: InMemorySecretStore => Json.obj(("type", Json.string(x.getClass.getSimpleName)))
+    case other => Json.string("Error: " + other.toString)
+  }
+  implicit val decodeSecretStore: Decoder[SecretStoreApi] = Decoder.instance { c =>
+    c.downField("type").as[String].flatMap {
+      case "InMemorySecretStore" => Xor.right(defaultSecretStore)
+      case other  => Xor.left(DecodingFailure(s"Invalid secretStore: $other", c.history))
     }
   }
 
-  // Flaggable for ServiceIds
-  implicit val serviceIdsFlaggable = new Flaggable[Set[ServiceIdentifier]] {
-    def parse (s: String): Set[ServiceIdentifier] = {
+  /**
+   * Encoder/Decoder for LoginManager
+   *
+   * Note that Decoder for LoginManager does not work standalone, it can be only used
+   * while decoding the entire ServerConfig due to dependency issues
+   */
+  implicit val encodeLoginManager: Encoder[LoginManager] = Encoder.instance { lm =>
+    Json.fromFields(Seq(
+      ("name", lm.name.asJson),
+      ("path", lm.path.asJson),
+      ("hosts", lm.hosts.asJson),
+      ("loginPath", lm.loginPath.asJson),
+      ("identityManager", lm.identityManager.name.asJson),
+      ("accessManager", lm.accessManager.name.asJson)))
+  }
+  def decodeLoginManager(ims: Map[String, Manager], ams: Map[String, Manager]): Decoder[LoginManager] =
+    Decoder.instance { c =>
+      for {
+        name <- c.downField("name").as[String]
+        path <- c.downField("path").as[Path]
+        hosts <- c.downField("hosts").as[String]
+        loginPath <- c.downField("loginPath").as[Path]
+        ipName <- c.downField("identityManager").as[String]
+        im <- Xor.fromOption(
+          ims.get(ipName),
+          DecodingFailure(s"No IdentityManager $ipName found", c.history)
+        )
+        apName <- c.downField("accessManager").as[String]
+        am <- Xor.fromOption(
+          ams.get(apName),
+          DecodingFailure(s"No AccessManager $apName found", c.history)
+        )
+      } yield LoginManager(name, path, hosts, loginPath, im, am)
+    }
 
-      // Set of ServiceIdentifier
-      implicit val encodePath: Encoder[Path] = Encoder.instance(p => Json.obj( ("str", Json.string(p.toString())) ))
-      implicit val decodePath: Decoder[Path] = Decoder.instance(c =>
-        for {
-          str <- c.downField("str").as[String]
-        } yield Path(str)
-      )
+  // Encoder/Decoder for ServiceIdentifier
+  implicit val encodeServiceIdentifier: Encoder[ServiceIdentifier] = Encoder.instance { sid =>
+    Json.fromFields(Seq(
+      ("name", sid.name.asJson),
+      ("hosts", sid.hosts.asJson),
+      ("path", sid.path.asJson),
+      ("subdomain", sid.subdomain.asJson),
+      ("loginManager", sid.loginManager.name.asJson)))
+  }
+  def decodeServiceIdentifier(lms: Map[String, LoginManager]): Decoder[ServiceIdentifier] =
+    Decoder.instance { c =>
+      for {
+        name <- c.downField("name").as[String]
+        hosts <- c.downField("hosts").as[String]
+        path <- c.downField("path").as[Path]
+        subdomain <- c.downField("subdomain").as[String]
+        lmName <- c.downField("loginManager").as[String]
+        lm <- Xor.fromOption(
+          lms.get(lmName),
+          DecodingFailure(s"No LoginManager $lmName found", c.history)
+        )
+      } yield ServiceIdentifier(name, hosts, path, subdomain, lm)
+    }
 
-      decode[Set[ServiceIdentifier]](Source.fromFile(s).mkString) match {
-        case Xor.Right(a) => a
-        case Xor.Left(b) => throw new ConfigError(b.getClass.getSimpleName + ": " + b.getMessage())
-      }
+  /**
+   * Decoder for ServerConfig (Using circe default encoder for encoding)
+   */
+  implicit val serverConfigDecoder: Decoder[ServerConfig] = Decoder.instance { c =>
+    for {
+      secretStore <- c.downField("secretStore").as[SecretStoreApi]
+      sessionStore <- c.downField("sessionStore").as[SessionStore]
+      ims <- c.downField("identityManagers").as[Set[Manager]]
+      ams <- c.downField("accessManagers").as[Set[Manager]]
+      lms <- c.downField("loginManagers").as(Decoder.decodeSet(
+        decodeLoginManager(ims.map(im => im.name -> im).toMap, ams.map(am => am.name -> am).toMap)))
+      sids <- c.downField("serviceIdentifiers").as(Decoder.decodeSet(
+        decodeServiceIdentifier(lms.map(lm => lm.name -> lm).toMap)))
+    } yield ServerConfig(secretStore, sessionStore, sids, lms, ims, ams)
+  }
+
+  /**
+   * Validates the BorderPatrol Configuration
+   * - for duplicates
+   *
+   * @param serverConfig
+   */
+  def validate(serverConfig: ServerConfig): Unit = {
+    // Find if IdentityManagers have duplicate entries
+    if (serverConfig.identityManagers.size > serverConfig.identityManagers.map(im => im.name).size)
+      throw new DuplicateConfigError("name", "identityManagers")
+
+    // Find if Managers have duplicate entries
+    if (serverConfig.accessManagers.size > serverConfig.accessManagers.map(am => am.name).size)
+      throw new DuplicateConfigError("name", "accessManagers")
+
+    // Find if LoginManagers have duplicate entries
+    if (serverConfig.loginManagers.size > serverConfig.loginManagers.map(lm => lm.name).size)
+      throw new DuplicateConfigError("name", "loginManagers")
+
+    // Find if ServiceIdentifiers have duplicate entries
+    if (serverConfig.serviceIdentifiers.size >
+      serverConfig.serviceIdentifiers.map(sid => (sid.path, sid.subdomain)).size)
+      throw new DuplicateConfigError("path and subdomain", "serviceIdentifiers")
+  }
+
+  /**
+   * Reads BorderPatrol configuration from the given filename
+   *
+   * @param filename
+   * @return ServerConfig
+   */
+  def readServerConfig(filename: String) : ServerConfig = {
+    decode[ServerConfig](Source.fromFile(filename).mkString) match {
+      case Xor.Right(a) => validate(a); a
+      case Xor.Left(b) => throw ConfigError("Failed to decode following fields: " +
+        (serverConfigFields.filter(b.getMessage contains _).reduceOption((a, b) => s"$a, $b") getOrElse "unknown"))
     }
   }
 }
@@ -81,18 +210,8 @@ object Config {
 trait Config {self: App =>
   import Config._
 
-  def defaultServiceIds: Set[ServiceIdentifier] = serviceIdsFlaggable.parse(defaultServiceIdsFile)
-
   // Flag for Secret Store
-  val secretStore = flag[SecretStoreApi]("secretStore.servers", defaultSecretStore,
-    "CSV of Memcached hosts for Secret Store. Default is in-memory store.")
-
-  // Flag for Session Store
-  val sessionStore = flag[SessionStore]("sessionStore.servers", defaultSessionStore,
-    "CSV of Memcached hosts for Session Store. Default is in-memory store.")
-
-  val serviceIds = flag[Set[ServiceIdentifier]]("serviceIds.file",
-    defaultServiceIds,
-    "Filename to read Service Identifiers in JSON format")
+  val configFile = flag("configFile", defaultConfigFile,
+    "BorderPatrol config file in JSON format")
 }
 

--- a/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
@@ -23,7 +23,6 @@
  */
 package com.lookout.borderpatrol.example
 
-import com.lookout.borderpatrol.Binder._
 import com.lookout.borderpatrol.auth._
 import com.lookout.borderpatrol.auth.keymaster._
 import com.lookout.borderpatrol.auth.keymaster.Keymaster._
@@ -134,24 +133,6 @@ object MockService {
 }
 
 object service {
-
-  //  Keymaster Identity provider service Chain
-  def keymasterIdentityProviderChain1(implicit config: ServerConfig): Service[SessionIdRequest, Response] = {
-    implicit val secretStore = config.secretStore
-
-    new KeymasterMethodMuxLoginFilter(new LoginManagerBinder) andThen
-      new KeymasterPostLoginFilter(config.sessionStore) andThen
-      new KeymasterIdentityProvider(new ManagerBinder)
-  }
-
-  //  Keymaster Access Issuer service Chain
-  def keymasterAccessIssuerChain1(implicit config: ServerConfig): Service[SessionIdRequest, Response] = {
-    implicit val secretStore = config.secretStore
-
-    new IdentityFilter[Tokens](config.sessionStore) andThen
-      new KeymasterAccessFilter(new ServiceIdentifierBinder) andThen
-      new KeymasterAccessIssuer(new ManagerBinder, config.sessionStore)
-  }
 
   /**
    * Glue that DEMUXes the chain into appropriate identityProvider or accessIssuer

--- a/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
@@ -23,25 +23,26 @@
  */
 package com.lookout.borderpatrol.example
 
+import com.lookout.borderpatrol.Binder._
 import com.lookout.borderpatrol.auth._
 import com.lookout.borderpatrol.auth.keymaster._
 import com.lookout.borderpatrol.auth.keymaster.Keymaster._
 import com.lookout.borderpatrol.auth.keymaster.Tokens._
-import com.lookout.borderpatrol.{ServiceIdentifier, ServiceMatcher}
+import com.lookout.borderpatrol.{ServiceMatcher, Manager}
 import com.lookout.borderpatrol.sessionx._
 import com.lookout.borderpatrol.util.Combinators._
 import com.twitter.io.Buf
 import com.twitter.finagle.httpx.{Method, Request, Response, Status}
 import com.twitter.finagle.httpx.path._
 import com.twitter.finagle.httpx.service.RoutingService
-import com.twitter.finagle.{Httpx, Service}
+import com.twitter.finagle.Service
 import com.twitter.util.Future
 import io.finch.response.ResponseBuilder
 
 
-object service {
+object MockService {
 
-  //  Mock Keymaster identityProvider
+  //  Mock Keymaster identityManager
   val mockKeymasterIdentityService = new Service[Request, Response] {
 
     val userMap: Map[String, String] = Map(
@@ -58,7 +59,8 @@ object service {
         if userMap(email) == (pass)
       } yield tap(Response(Status.Ok))(res => {
           res.contentString = TokensEncoder(tokens).toString()
-          res.contentType = "application/json"})) handle {
+          res.contentType = "application/json"
+        })) handle {
         case ex => Response(Status.Unauthorized)
       }
     }
@@ -82,7 +84,7 @@ object service {
     val loginForm = Buf.Utf8(
       """<html><body>
         |<h1>Example Account Service Login</h1>
-        |<form action="/login" method="post">
+        |<form action="/signin" method="post">
         |<label>username</label><input type="text" name="username" />
         |<label>password</label><input type="password" name="password" />
         |<input type="submit" name="login" value="login" />
@@ -110,109 +112,102 @@ object service {
           |<html><body>
           |<h1>Welcome to Service @(${request.path})</h1>
           |</body></html>
-        """.stripMargin
+          """.stripMargin
         res.contentType = "text/html"
       }).toFuture
   }
 
-  //  Clients & paths to those mocked services
-  //    """
-  //  {
-  //    "loginProviders": [
-  //      {
-  //        "name": "checkpoint",
-  //        "path": "/a",
-  //        "hosts": "localhost:8080,localhost:8081",
-  //        "loginPath": "/login", # what we listen for on POST to route to the identity provider
-  //        "identityProvider": "keymaster"
-  //      },
-  //      {
-  //        "name": "umbrella",
-  //        "loginPath": "/login/sso/umbrella",
-  //        "identityProvider": "keymaster"
-  //      },
-  //      {
-  //        "name": "bookface",
-  //        "loginPath": "/login/sso/bookface",
-  //        "identityProvider": "keymaster"
-  //      }
-  //    ],
-  //    "identityProviders": [
-  //      {
-  //        "name": "keymaster",
-  //        "path": "/identityProvider",
-  //        "hosts": "localhost:8081,localhost:8082"
-  //      }
-  //    ]
-  //    "accessProviders": [
-  //      {
-  //        "name": "keymaster",
-  //        "path": "/accessIssuer",
-  //        "hosts": "localhost:8081,localhost:8082"
-  //      }
-  //    ]
-  //  }
-  //    """
-  case class IdProvider(name: String, path: Path, hosts: String)
-  case class AccessProvider(name: String, path: Path, hosts: String)
-  case class LoginProvider(name: String, path: Path, hosts: String, loginPath: Path, idProvider: IdProvider)
-
-  val keymasterIdProvider = IdProvider("keymaster", Path("/identityProvider"), "localhost:8081")
-  val keymasterAccessProvider = IdProvider("keymaster", Path("/accessIssuer"), "localhost:8081")
-  val checkpointLoginProvider = LoginProvider("checkpoint", Path("/a"), "localhost:8081", Path("/login"),
-    keymasterIdProvider)
-
-  //  Login path
-  def keymasterIdpService(implicit config: ServerConfig): Service[Request, Response] = {
-    implicit val secretStore = config.secretStore
-    val checkpointSeviceId = ServiceIdentifier("checkpoint", checkpointLoginProvider.path, "",
-      checkpointLoginProvider.loginPath)
-    val serviceMatcher = ServiceMatcher(config.serviceIdentifiers + checkpointSeviceId)
-    val keymasterClient = Httpx.newService(keymasterIdProvider.hosts)
-    val checkpointClient = Httpx.newService(checkpointLoginProvider.hosts)
-
-    new ExceptionFilter andThen
-    new ServiceFilter(serviceMatcher) andThen
-    new SessionIdFilter(config.sessionStore) andThen
-    new KeymasterMethodMuxLoginFilter(checkpointClient, checkpointLoginProvider.loginPath) andThen
-    new KeymasterPostLoginFilter(config.sessionStore) andThen
-    new KeymasterIdentityProvider(keymasterClient, keymasterIdProvider.path)
-  }
-
-  //  All other requests
-  def allOtherRequests(implicit config: ServerConfig): Service[Request, Response] = {
-    implicit val secretStore = config.secretStore
-    val serviceMatcher = ServiceMatcher(config.serviceIdentifiers)
-    val upstreamClient = Httpx.newService("localhost:8081") // Comes from SeviceIdentifier in Future
-    val keymasterClient = Httpx.newService(keymasterAccessProvider.hosts)
-
-    new ExceptionFilter andThen
-    new ServiceFilter(serviceMatcher) andThen
-    new SessionIdFilter(config.sessionStore) andThen
-    new IdentityFilter[Tokens](config.sessionStore) andThen
-    new KeymasterAccessFilter(upstreamClient) andThen
-    new KeymasterAccessIssuer(keymasterClient, keymasterAccessProvider.path, config.sessionStore)
-  }
-
-  def getRoutingService(implicit config: ServerConfig): Service[Request, Response] = {
-
-    RoutingService.byMethodAndPathObject {
-      case _ -> checkpointLoginProvider.loginPath => keymasterIdpService
-      case _ -> checkpointLoginProvider.path => keymasterIdpService // FIXME: /a/recover doesn't not work
-      case _ => allOtherRequests
-    }
-  }
-
   def getMockRoutingService(implicit config: ServerConfig): Service[Request, Response] = {
-    val mockProtectedPathMap = config.serviceIdentifiers.map(a => (a.path -> mockUpstreamService)).toMap
-    val mockKeymasterPathMap = Map(keymasterAccessProvider.path -> mockKeymasterAccessIssuerService,
-      keymasterIdProvider.path -> mockKeymasterIdentityService,
-      checkpointLoginProvider.loginPath -> mockCheckpointService,
-      checkpointLoginProvider.path -> mockUpstreamService) // FIXME: /a/recover doesn't not work
+    val checkpointLoginManager = config.findLoginManager("checkpoint")
+    val keymasterIdManager = config.findIdentityManager("keymaster")
+    val keymasterAccessManager = config.findAccessManager("keymaster")
+
+    val mockKeymasterPathMap = Map(keymasterAccessManager.path -> mockKeymasterAccessIssuerService,
+      keymasterIdManager.path -> mockKeymasterIdentityService,
+      checkpointLoginManager.path -> mockCheckpointService)
 
     RoutingService.byMethodAndPathObject {
       case _ -> path if mockKeymasterPathMap.contains(path) => mockKeymasterPathMap(path)
-      case _ -> path if mockProtectedPathMap.contains(path) => mockProtectedPathMap(path)
+      case _ => mockUpstreamService
     }
+  }
+}
+
+object service {
+
+  //  Keymaster Identity provider service Chain
+  def keymasterIdentityProviderChain1(implicit config: ServerConfig): Service[SessionIdRequest, Response] = {
+    implicit val secretStore = config.secretStore
+
+    new KeymasterMethodMuxLoginFilter(new LoginManagerBinder) andThen
+      new KeymasterPostLoginFilter(config.sessionStore) andThen
+      new KeymasterIdentityProvider(new ManagerBinder)
+  }
+
+  //  Keymaster Access Issuer service Chain
+  def keymasterAccessIssuerChain1(implicit config: ServerConfig): Service[SessionIdRequest, Response] = {
+    implicit val secretStore = config.secretStore
+
+    new IdentityFilter[Tokens](config.sessionStore) andThen
+      new KeymasterAccessFilter(new ServiceIdentifierBinder) andThen
+      new KeymasterAccessIssuer(new ManagerBinder, config.sessionStore)
+  }
+
+  /**
+   * Glue that DEMUXes the chain into appropriate identityProvider or accessIssuer
+   *
+   * @param accessIssuerMap
+   * @param identityProviderMap
+   */
+  case class MainGlueService(identityProviderMap: Map[String, Service[SessionIdRequest, Response]],
+                             accessIssuerMap: Map[String, Service[SessionIdRequest, Response]])
+  extends Service[SessionIdRequest, Response] {
+
+    def getIdentityProviderService(identityManager: Manager): Service[SessionIdRequest, Response] =
+      identityProviderMap.get(identityManager.name) match {
+        case Some(s) => s
+        case None => throw InvalidConfigError("Failed to find IdentityProvider Service Chain for " +
+          identityManager.name)
+      }
+
+    def getAccessIssuerService(accessManager: Manager): Service[SessionIdRequest, Response] =
+      accessIssuerMap.get(accessManager.name) match {
+        case Some(s) => s
+        case None => throw InvalidConfigError("Failed to find AccessIssuer Service Chain for " +
+          accessManager.name)
+      }
+
+    def apply(req: SessionIdRequest): Future[Response] = {
+      val p = Path(req.req.req.path)
+      /* LoginPath that processes the login response */
+      if (p.startsWith(req.req.serviceId.loginManager.loginPath))
+        getIdentityProviderService(req.req.serviceId.loginManager.identityManager)(req)
+      /* Path that handles the LoginManager specific routes */
+      else if (p.startsWith(req.req.serviceId.loginManager.path))
+        getIdentityProviderService(req.req.serviceId.loginManager.identityManager)(req)
+      /* Upstream service path */
+      else if (p.startsWith(req.req.serviceId.path))
+        getAccessIssuerService(req.req.serviceId.loginManager.accessManager)(req)
+      else tap(Response(Status.NotFound))(r => {
+        r.contentString = s"${req.req.req.path}: No IdentityProvider or AccessIssuer found. " +
+          s"Returning (${Status.NotFound.code})"
+        r.contentType = "text/plain"
+      }).toFuture
+    }
+  }
+
+  /**
+   * The sole entry point for all service chains
+   */
+  def MainServiceChain(implicit config: ServerConfig): Service[Request, Response] = {
+    implicit val secretStore = config.secretStore
+    val serviceMatcher = ServiceMatcher(config.serviceIdentifiers)
+    val identityProviderMap = Map("keymaster" -> keymasterIdentityProviderChain(config.sessionStore))
+    val accessIssuerMap = Map("keymaster" -> keymasterAccessIssuerChain(config.sessionStore))
+
+    new ExceptionFilter andThen
+      new ServiceFilter(serviceMatcher) andThen
+      new SessionIdFilter(config.sessionStore) andThen
+      new MainGlueService(identityProviderMap, accessIssuerMap)
   }
 }

--- a/serviceids.json
+++ b/serviceids.json
@@ -1,22 +1,48 @@
-[
-  {
-    "login" : {
-      "str" : "/login"
-    },
-    "subdomain" : "ent",
-    "path" : {
-      "str" : "/ent"
-    },
-    "name" : "one"
+{
+  "accessManagers": [
+    {
+      "hosts": "localhost:8081",
+      "path": "/accessIssuer",
+      "name": "keymaster"
+    }
+  ],
+  "sessionStore": {
+    "type": "InMemoryStore$"
   },
-  {
-    "login" : {
-      "str" : "/login"
+  "loginManagers": [
+    {
+      "name": "checkpoint",
+      "path": "/a",
+      "identityManager": "keymaster",
+      "accessManager": "keymaster",
+      "loginPath": "/signin",
+      "hosts": "localhost:8081"
+    }
+  ],
+  "secretStore": {
+    "type": "InMemorySecretStore"
+  },
+  "identityManagers": [
+    {
+      "hosts": "localhost:8081",
+      "path": "/identityManager",
+      "name": "keymaster"
+    }
+  ],
+  "serviceIdentifiers": [
+    {
+      "hosts": "localhost:8081",
+      "loginManager": "checkpoint",
+      "subdomain": "ent",
+      "path": "/ent",
+      "name": "one"
     },
-    "subdomain" : "admin",
-    "path" : {
-      "str" : "/admin/metrics.json"
-    },
-    "name" : "admin"
-  }
-]
+    {
+      "hosts": "localhost:8081",
+      "loginManager": "checkpoint",
+      "subdomain": "admin",
+      "path": "/admin/metrics.json",
+      "name": "admin"
+    }
+  ]
+}


### PR DESCRIPTION
Also:
- rename identityProvider, loginProvider, accessProvider, etc to identityManager,
  loginManager, accessManager, etc
- Move keymasterIdentityProvider service chain and keymasterAccessIssuer service
  chain to keymaster (common) code.
- Add Binders to dynamically bind to upstream or identity or access or login
  service on the fly.
- Modify ServiceIdentifier to include loginManager and hosts.
- Modify ServiceMatchers to match subdomain first and then match the
  serviceIdentifier path or loginManager paths.