### PR TITLE
Added BorderFilter to detect if session is tagged i.e. authenticated or not

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
@@ -87,7 +87,7 @@ object Keymaster {
       createIdentifyReq(req).fold(Future.value(Response(Status.BadRequest)))(credReq =>
         for {
           tokenResponse <- service(credReq)
-          session <- Session(tokenResponse.identity.id, true)
+          session <- Session.applyTagged(tokenResponse.identity.id)
           _ <- store.update[Tokens](session)
           originReq <- getRequestFromSessionStore(req.sid)
           _ <- store.delete(req.sid)

--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
@@ -87,7 +87,7 @@ object Keymaster {
       createIdentifyReq(req).fold(Future.value(Response(Status.BadRequest)))(credReq =>
         for {
           tokenResponse <- service(credReq)
-          session <- Session.applyTagged(tokenResponse.identity.id)
+          session <- Session(tokenResponse.identity.id, SessionId.authenticatedTagId)
           _ <- store.update[Tokens](session)
           originReq <- getRequestFromSessionStore(req.sid)
           _ <- store.delete(req.sid)

--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
@@ -87,7 +87,7 @@ object Keymaster {
       createIdentifyReq(req).fold(Future.value(Response(Status.BadRequest)))(credReq =>
         for {
           tokenResponse <- service(credReq)
-          session <- Session(tokenResponse.identity.id)
+          session <- Session(tokenResponse.identity.id, true)
           _ <- store.update[Tokens](session)
           originReq <- getRequestFromSessionStore(req.sid)
           _ <- store.delete(req.sid)

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
@@ -143,7 +143,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     }
 
     // Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     // Login POST request
     val loginRequest = req("enterprise", "/login", ("username" -> "foo"), ("password" -> "bar"))
@@ -168,7 +168,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
   it should "return BadRequest Status if credentials are not present in the request" in {
     // Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     // Login POST request
     val loginRequest = req("enterprise", "/login", ("username" -> "foo"))
@@ -183,7 +183,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
   it should "return OriginalRequestNotFound if it fails find the original request from sessionStore" in {
     // Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     // Login POST request
     val loginRequest = req("enterprise", "/login", ("username" -> "foo"), ("password" -> "bar"))
@@ -210,7 +210,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val mockSessionStore = MemcachedStore(FailingMockClient)
 
     // Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     // Login POST request
     val loginRequest = req("enterprise", "/login", ("username" -> "foo"), ("password" -> "bar"))
@@ -232,7 +232,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val testAccessManagerBinder = mkTestManagerBinder {
       request => { assert(false); Response(Status.Ok).toFuture }
     }
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     // Execute
     val output = KeymasterAccessIssuer(testAccessManagerBinder, sessionStore)(KeymasterAccessReq(Id(tokens2), one, sessionId))
@@ -249,7 +249,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
         res.contentType = "application/json"
       }).toFuture
     }}
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
     sessionStore.update[Tokens](Session(sessionId, tokens))
 
     // Execute
@@ -263,7 +263,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
   it should "propagate the error Status code returned by the Keymaster service, as the AccessIssuerError exception" in {
     val testAccessManagerBinder = mkTestManagerBinder { request => Response(Status.NotFound).toFuture }
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     // Execute
     val output = KeymasterAccessIssuer(testAccessManagerBinder, sessionStore)(KeymasterAccessReq(Id(tokens), one, sessionId))
@@ -283,7 +283,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
         res.contentType = "application/json"
       }).toFuture
     }
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     // Execute
     val output = KeymasterAccessIssuer(testAccessManagerBinder, sessionStore)(KeymasterAccessReq(Id(tokens), one, sessionId))
@@ -302,7 +302,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
         res.contentType = "application/json"
       }).toFuture
     }
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     // Execute
     val output = KeymasterAccessIssuer(testAccessManagerBinder, sessionStore)(KeymasterAccessReq(Id(tokens), one, sessionId))
@@ -330,7 +330,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     }
 
     // Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     // Create request
     val request = req("enterprise", "/dang")
@@ -356,7 +356,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     }
 
     // Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     // Create request
     val request = req("enterprise", "/dang")
@@ -382,7 +382,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     }
 
     // Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     // Create request
     val request = req("enterprise", "/dang")
@@ -404,7 +404,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val testLoginManagerBinder = mkTestLoginManagerBinder { _ => Response(Status.Ok).toFuture }
 
     // Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     // Create request
     val request = Request(Method.Get, "/ent")
@@ -422,7 +422,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val testLoginManagerBinder = mkTestLoginManagerBinder { _ => fail("Should not get here") }
 
     // Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     // Create request
     val request = Request(Method.Post, "/ent")
@@ -440,7 +440,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val testLoginManagerBinder = mkTestLoginManagerBinder { _ => Response(Status.Ok).toFuture }
 
     // Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     // Create request
     val request = Request(Method.Head, "/ent")
@@ -464,7 +464,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
     try {
       // Allocate and Session
-      val sessionId = sessionid.next()
+      val sessionId = sessionid.untagged
 
       // Login manager request
       val loginRequest = req("enterprise", checkpointLoginManager.path.toString,
@@ -498,7 +498,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
     try {
       // Allocate and Session
-      val sessionId = sessionid.next()
+      val sessionId = sessionid.untagged
 
       // Login manager request
       val loginRequest = Request(Method.Post, Request.queryString(checkpointLoginManager.loginPath.toString,
@@ -535,7 +535,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
     try {
       // Allocate and Session
-      val sessionId = sessionid.next()
+      val sessionId = sessionid.untagged
 
       // Original request
       val origReq = req("enterprise", "/ent")

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
@@ -143,7 +143,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     }
 
     // Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     // Login POST request
     val loginRequest = req("enterprise", "/login", ("username" -> "foo"), ("password" -> "bar"))
@@ -168,7 +168,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
   it should "return BadRequest Status if credentials are not present in the request" in {
     // Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     // Login POST request
     val loginRequest = req("enterprise", "/login", ("username" -> "foo"))
@@ -183,7 +183,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
   it should "return OriginalRequestNotFound if it fails find the original request from sessionStore" in {
     // Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     // Login POST request
     val loginRequest = req("enterprise", "/login", ("username" -> "foo"), ("password" -> "bar"))
@@ -210,7 +210,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val mockSessionStore = MemcachedStore(FailingMockClient)
 
     // Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     // Login POST request
     val loginRequest = req("enterprise", "/login", ("username" -> "foo"), ("password" -> "bar"))
@@ -232,7 +232,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val testAccessManagerBinder = mkTestManagerBinder {
       request => { assert(false); Response(Status.Ok).toFuture }
     }
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     // Execute
     val output = KeymasterAccessIssuer(testAccessManagerBinder, sessionStore)(KeymasterAccessReq(Id(tokens2), one, sessionId))
@@ -249,7 +249,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
         res.contentType = "application/json"
       }).toFuture
     }}
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
     sessionStore.update[Tokens](Session(sessionId, tokens))
 
     // Execute
@@ -263,7 +263,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
   it should "propagate the error Status code returned by the Keymaster service, as the AccessIssuerError exception" in {
     val testAccessManagerBinder = mkTestManagerBinder { request => Response(Status.NotFound).toFuture }
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     // Execute
     val output = KeymasterAccessIssuer(testAccessManagerBinder, sessionStore)(KeymasterAccessReq(Id(tokens), one, sessionId))
@@ -283,7 +283,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
         res.contentType = "application/json"
       }).toFuture
     }
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     // Execute
     val output = KeymasterAccessIssuer(testAccessManagerBinder, sessionStore)(KeymasterAccessReq(Id(tokens), one, sessionId))
@@ -302,7 +302,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
         res.contentType = "application/json"
       }).toFuture
     }
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     // Execute
     val output = KeymasterAccessIssuer(testAccessManagerBinder, sessionStore)(KeymasterAccessReq(Id(tokens), one, sessionId))
@@ -330,7 +330,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     }
 
     // Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     // Create request
     val request = req("enterprise", "/dang")
@@ -356,7 +356,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     }
 
     // Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     // Create request
     val request = req("enterprise", "/dang")
@@ -382,7 +382,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     }
 
     // Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     // Create request
     val request = req("enterprise", "/dang")
@@ -404,7 +404,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val testLoginManagerBinder = mkTestLoginManagerBinder { _ => Response(Status.Ok).toFuture }
 
     // Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     // Create request
     val request = Request(Method.Get, "/ent")
@@ -422,7 +422,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val testLoginManagerBinder = mkTestLoginManagerBinder { _ => fail("Should not get here") }
 
     // Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     // Create request
     val request = Request(Method.Post, "/ent")
@@ -440,7 +440,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val testLoginManagerBinder = mkTestLoginManagerBinder { _ => Response(Status.Ok).toFuture }
 
     // Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     // Create request
     val request = Request(Method.Head, "/ent")
@@ -464,7 +464,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
     try {
       // Allocate and Session
-      val sessionId = sessionid.next
+      val sessionId = sessionid.next()
 
       // Login manager request
       val loginRequest = req("enterprise", checkpointLoginManager.path.toString,
@@ -498,7 +498,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
     try {
       // Allocate and Session
-      val sessionId = sessionid.next
+      val sessionId = sessionid.next()
 
       // Login manager request
       val loginRequest = Request(Method.Post, Request.queryString(checkpointLoginManager.loginPath.toString,
@@ -535,7 +535,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
     try {
       // Allocate and Session
-      val sessionId = sessionid.next
+      val sessionId = sessionid.next()
 
       // Original request
       val origReq = req("enterprise", "/ent")

--- a/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
@@ -42,7 +42,7 @@ object Binder {
    * @tparam A
    */
   abstract class MBinder[A: BinderContext](cache: mutable.Map[String, Service[Request, Response]] =
-                                       mutable.Map.empty[String, Service[Request, Response]])
+                                           mutable.Map.empty[String, Service[Request, Response]])
       extends Service[BindRequest[A], Response] {
     def apply(req: BindRequest[A]): Future[Response] =
       this.synchronized(cache.getOrElse(req.name, {

--- a/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
@@ -16,8 +16,10 @@ import com.twitter.finagle.httpx.path.Path
  */
 case class ServiceIdentifier(name: String, hosts: Set[URL], path: Path, subdomain: String,
                              loginManager: LoginManager) {
-  def isMatchingPath(p: Path): Boolean = isServicePath(p) || isLoginManagerPath(p)
-  def isServicePath(p: Path): Boolean = p.startsWith(path)
+  def isMatchingPath(p: Path): Boolean =
+    isServicePath(p) || isLoginManagerPath(p)
+  def isServicePath(p: Path): Boolean =
+    p.startsWith(path)
   def isLoginManagerPath(p: Path): Boolean =
     !Set(loginManager.path, loginManager.loginPath).filter(p.startsWith(_)).isEmpty
 }

--- a/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
@@ -12,7 +12,7 @@ import com.twitter.finagle.httpx.path.Path
  * @param hosts The list of URLs to upstream service
  * @param path The external url path prefix that routes to the internal service
  * @param subdomain A default fall-back when path is only `/`
- * @param loginManager The location to send a user when a request to this service is Unauthorized
+ * @param loginManager The location to send a user when a request to this service is Unauthenticated
  */
 case class ServiceIdentifier(name: String, hosts: Set[URL], path: Path, subdomain: String,
                              loginManager: LoginManager) {

--- a/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
@@ -15,4 +15,9 @@ import com.twitter.finagle.httpx.path.Path
  * @param loginManager The location to send a user when a request to this service is Unauthorized
  */
 case class ServiceIdentifier(name: String, hosts: Set[URL], path: Path, subdomain: String,
-                             loginManager: LoginManager)
+                             loginManager: LoginManager) {
+  def isMatchingPath(p: Path): Boolean = isServicePath(p) || isLoginManagerPath(p)
+  def isServicePath(p: Path): Boolean = p.startsWith(path)
+  def isLoginManagerPath(p: Path): Boolean =
+    !Set(loginManager.path, loginManager.loginPath).filter(p.startsWith(_)).isEmpty
+}

--- a/core/src/main/scala/com/lookout/borderpatrol/ServiceMatcher.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/ServiceMatcher.scala
@@ -72,9 +72,6 @@ case class ServiceMatcher(services: Set[ServiceIdentifier]) {
    * Derive a ServiceIdentifier from an `httpx.Request`
    */
   def get(req: Request): Option[ServiceIdentifier] =
-    req.host.flatMap(subdomain).filter(sid => {
-      val pathSet = Set(sid.path, sid.loginManager.path, sid.loginManager.loginPath)
-      !pathSet.filter(Path(req.path).startsWith(_)).isEmpty
-    })
+    req.host.flatMap(subdomain).filter(sid => sid.isMatchingPath(Path(req.path)))
 }
 

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
@@ -64,13 +64,13 @@ case class SessionIdFilter(store: SessionStore)(implicit secretStore: SecretStor
 /**
  * Determine if the session is tagged (i.e. authenticated) or not and force changes to request path
  * E.g.
- * - If SessionId is tagged (i.e. al, and the path is NOT a service path, then redirect it to service identifier path
- * - If SessionId is NOT tagged and path is a service path, then redirect to login page
+ * - If SessionId is authenticated and the path is NOT a service path, then redirect it to service identifier path
+ * - If SessionId is NOT authenticated and path is a service path, then redirect to login page
  */
 class BorderFilter extends Filter[SessionIdRequest, Response, SessionIdRequest, Response] {
 
   def apply(req: SessionIdRequest, service: Service[SessionIdRequest, Response]): Future[Response] =
-    if (SessionId.isTagged(req.sid))
+    if (SessionId.isAuthenticated(req.sid))
       if (!req.req.serviceId.isServicePath(Path(req.req.req.path)))
         tap(Response(Status.Found))(res => res.location = req.req.serviceId.path.toString).toFuture
       else service(req)

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
@@ -52,7 +52,7 @@ case class SessionIdFilter(store: SessionStore)(implicit secretStore: SecretStor
       case Success(sid) => service(SessionIdRequest(req, sid))
       case Failure(e) =>
         for {
-          session <- Session(req.req, false)
+          session <- Session(req.req)
           _ <- store.update(session)
         } yield tap(Response(Status.Found)) { res =>
           res.location = req.serviceId.loginManager.path.toString
@@ -98,7 +98,7 @@ class IdentityFilter[A : SessionDataEncoder](store: SessionStore)(implicit secre
     identity(req.sid).flatMap(i => i match {
       case id: Id[A] => service(AccessIdRequest(req, id))
       case EmptyIdentity => for {
-        s <- Session(req.req.req, false)
+        s <- Session(req.req.req)
         _ <- store.update(s)
       } yield tap(Response(Status.Found)) { res =>
           res.location = req.req.serviceId.loginManager.path.toString // set to login url

--- a/core/src/main/scala/com/lookout/borderpatrol/crypto/CryptKey.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/crypto/CryptKey.scala
@@ -54,8 +54,8 @@ case class CryptKey(keyBytes: Array[Byte],
  * Alternatively, you could create a new SessionId every time Session data is stored
  */
 object CryptKey {
-  def apply(id: SessionId): CryptKey =
-    CryptKey(id.entropy.toArray, id.secret.entropy.toArray)
+  def apply(sessionId: SessionId): CryptKey =
+    CryptKey(sessionId.entropy.toArray, sessionId.secret.entropy.toArray)
 
   def apply(session: Session[_]): CryptKey =
     apply(session.id)

--- a/core/src/main/scala/com/lookout/borderpatrol/crypto/Signer.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/crypto/Signer.scala
@@ -12,6 +12,7 @@ import com.lookout.borderpatrol.util.Combinators.tap
 trait Signer {
   val algo: String
   val key: Key
+  lazy val hmac: Mac = tap(Mac.getInstance(algo))(mac => mac.init(key))
 
   /**
    * Sign the input bytes using configured algorithm
@@ -19,6 +20,6 @@ trait Signer {
    * @return Signature
    */
   def sign(bytes: IndexedSeq[Byte]): Signature =
-    tap(Mac.getInstance(algo))(mac => mac.init(key)).doFinal(bytes.toArray).toIndexedSeq
+   synchronized(hmac.doFinal(bytes.toArray).toIndexedSeq)
 }
 

--- a/core/src/main/scala/com/lookout/borderpatrol/crypto/Signer.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/crypto/Signer.scala
@@ -12,7 +12,8 @@ import com.lookout.borderpatrol.util.Combinators.tap
 trait Signer {
   val algo: String
   val key: Key
-  lazy val hmac: Mac = tap(Mac.getInstance(algo))(mac => mac.init(key))
+  def hmac: Mac =
+    tap(Mac.getInstance(algo))(mac => mac.init(key))
 
   /**
    * Sign the input bytes using configured algorithm
@@ -20,6 +21,6 @@ trait Signer {
    * @return Signature
    */
   def sign(bytes: IndexedSeq[Byte]): Signature =
-   synchronized(hmac.doFinal(bytes.toArray).toIndexedSeq)
+    hmac.doFinal(bytes.toArray).toIndexedSeq
 }
 

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Secret.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Secret.scala
@@ -30,14 +30,14 @@ object Secret {
   import Generator.EntropyGenerator
 
   private[sessionx] val entropySize = 16
-  private[sessionx] val idSize = 1
+  private[sessionx] val idSize = 2
   private[sessionx] val lifetime = Duration(1, TimeUnit.DAYS)
 
   private[borderpatrol] def currentExpiry: Time =
     Time.now + lifetime
 
   private[sessionx] def id: SecretId =
-    EntropyGenerator(idSize).head
+    EntropyGenerator(idSize)
 
   private[sessionx] def entropy: Entropy =
     EntropyGenerator(entropySize)

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Session.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Session.scala
@@ -80,7 +80,8 @@ object Session {
    * @tparam A
    * @return Session
    */
-  def apply[A](data: A, tagId: TagId = SessionId.nullTagId)(implicit store: SecretStoreApi): Future[Session[A]] =
-    SessionId.next(tagId) map (Session(_, data))
+  def apply[A](data: A, tag: Tag = Untagged)(implicit store: SecretStoreApi): Future[Session[A]] =
+    if (Tag.authenticated(tag)) SessionId.authenticated map (Session(_, data))
+    else SessionId.untagged map (Session(_, data))
 }
 

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Session.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Session.scala
@@ -80,8 +80,10 @@ object Session {
    * @tparam A
    * @return Session
    */
-  def apply[A](data: A, tag: Tag = Untagged)(implicit store: SecretStoreApi): Future[Session[A]] =
-    if (Tag.authenticated(tag)) SessionId.authenticated map (Session(_, data))
-    else SessionId.untagged map (Session(_, data))
+  def apply[A](data: A, tag: Tag = Untagged)(implicit store: SecretStoreApi): Future[Session[A]] = tag match {
+    case AuthenticatedTag => SessionId.authenticated map (Session(_, data))
+    case Untagged => SessionId.untagged map (Session (_, data) )
+    case _ => new SessionError("Invalid SessionId Tag found").toFutureException
+  }
 }
 

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Session.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Session.scala
@@ -80,17 +80,7 @@ object Session {
    * @tparam A
    * @return Session
    */
-  def apply[A](data: A)(implicit store: SecretStoreApi): Future[Session[A]] =
-    SessionId.next map (Session(_, data))
-
-  /**
-   * Generate a new Session with tagged SessionId
-   * @param data value you want to store
-   * @param store the secret store to fetch current secret
-   * @tparam A
-   * @return Session
-   */
-  def applyTagged[A](data: A)(implicit store: SecretStoreApi): Future[Session[A]] =
-    SessionId.nextTagged map (Session(_, data))
+  def apply[A](data: A, tagId: TagId = SessionId.nullTagId)(implicit store: SecretStoreApi): Future[Session[A]] =
+    SessionId.next(tagId) map (Session(_, data))
 }
 

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Session.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Session.scala
@@ -65,7 +65,7 @@ object Session {
     }
 
   /**
-   * Primary mechanism for generating new [[Session]], returning a `Future` of the `Session[A]`
+   * Mechanism for generating new [[Session]], returning a `Future` of the `Session[A]`
    *
    * {{{
    *   val data = 1
@@ -78,10 +78,19 @@ object Session {
    * @param data value you want to store
    * @param store the secret store to fetch current secret
    * @tparam A
-   * @return
+   * @return Session
    */
-  def apply[A](data: A, tagged: Boolean)(implicit store: SecretStoreApi): Future[Session[A]] =
-    if (tagged) SessionId.nextTagged map (Session(_, data))
-    else SessionId.next map (Session(_, data))
+  def apply[A](data: A)(implicit store: SecretStoreApi): Future[Session[A]] =
+    SessionId.next map (Session(_, data))
+
+  /**
+   * Generate a new Session with tagged SessionId
+   * @param data value you want to store
+   * @param store the secret store to fetch current secret
+   * @tparam A
+   * @return Session
+   */
+  def applyTagged[A](data: A)(implicit store: SecretStoreApi): Future[Session[A]] =
+    SessionId.nextTagged map (Session(_, data))
 }
 

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Session.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Session.scala
@@ -80,8 +80,8 @@ object Session {
    * @tparam A
    * @return
    */
-  def apply[A](data: A)(implicit store: SecretStoreApi): Future[Session[A]] =
-    SessionId.next map (Session(_, data))
-
+  def apply[A](data: A, tagged: Boolean)(implicit store: SecretStoreApi): Future[Session[A]] =
+    if (tagged) SessionId.nextTagged map (Session(_, data))
+    else SessionId.next map (Session(_, data))
 }
 

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/SessionId.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/SessionId.scala
@@ -38,8 +38,8 @@ object SessionId {
    * TagId is a byte that differentiates the set of SessionId from others.
    * Currently we are using a single bit for differentiation. Declare the constants here.
    */
-  val nullTagId: TagId = 0.toByte
-  val taggedId: TagId = 1.toByte
+  val nullTagId: TagId = 0.toByte /* Not tagged */
+  val authenticatedTagId: TagId = 1.toByte /* is session authenticated */
 
   private[this] def currentExpiry: Time =
     Time.now + lifetime
@@ -77,16 +77,8 @@ object SessionId {
    * @param store where to fetch the current [[Secret]] to sign this id
    * @return
    */
-  def next(implicit store: SecretStoreApi): Future[SessionId] =
-    (SessionId(currentExpiry, genEntropy, store.current, nullTagId)).toFuture
-
-  /**
-   * Create a tagged version of SessionId
-   * @param store where to fetch the current [[Secret]] to sign this id
-   * @return
-   */
-  def nextTagged(implicit store: SecretStoreApi): Future[SessionId] =
-    (SessionId(currentExpiry, genEntropy, store.current, taggedId)).toFuture
+  def next(tagId: TagId = nullTagId)(implicit store: SecretStoreApi): Future[SessionId] =
+    (SessionId(currentExpiry, genEntropy, store.current, tagId)).toFuture
 
   /**
    * Creates [[com.lookout.borderpatrol.sessionx.SessionId SessionId]] instances based on existing values
@@ -131,7 +123,8 @@ object SessionId {
    * @param id
    * @return
    */
-  def isTagged(id: SessionId): Boolean = id.tagId == taggedId
+  def isTagged(id: SessionId): Boolean = id.tagId != nullTagId
+  def isAuthenticated(id: SessionId): Boolean = id.tagId == authenticatedTagId
 
   object SessionIdInjections {
 

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/SessionId.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/SessionId.scala
@@ -17,6 +17,7 @@ import scala.util.{Success, Failure, Try}
  *  expires: [[com.twitter.util.Time Time]] => `Long` => `Array[Byte]`
  *  entropy: `Array[Byte]`
  *  secret: [[Secret]] => [[SecretId]]
+ *  tagId: => [[TagId]]
  *  signature: `Array[Byte]`
  *
  * @param expires the time at which this id is expired
@@ -32,6 +33,11 @@ object SessionId {
 
   val entropySize: Size = 16
   val lifetime = Duration(1, TimeUnit.DAYS)
+
+  /**
+   * TagId is a byte that differentiates the set of SessionId from others.
+   * Currently we are using a single bit for differentiation. Declare the constants here.
+   */
   val nullTagId: TagId = 0.toByte
   val taggedId: TagId = 1.toByte
 
@@ -51,7 +57,7 @@ object SessionId {
     Injection.long2BigEndian(t.inMilliseconds)
 
   private[sessionx] def payload(t: Time, e: Entropy, i: SecretId, tagId: TagId): Payload =
-    timeBytes(t) ++ e :+ i :+ tagId
+    timeBytes(t) ++ e :+ i :+ tagId /* Append the IndexSeq and Bytes to form payload */
 
   private[sessionx] def payload(id: SessionId): Payload =
     payload(id.expires, id.entropy, id.secret.id, id.tagId)

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Tag.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Tag.scala
@@ -20,7 +20,6 @@ object Tag {
     case _ => Untagged
   }
 
-
   // here is a partial function that acts like a finagle filter
   val authenticated: PartialFunction[Tag, Boolean] = {
     case AuthenticatedTag => true

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Tag.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Tag.scala
@@ -1,0 +1,29 @@
+package com.lookout.borderpatrol.sessionx
+
+/**
+ * Tag is a byte that help us differentiate the set of SessionId from others.
+ */
+trait Tag {
+  val id: Byte
+}
+case object Untagged extends Tag {
+  val id = 0.toByte
+}
+case object AuthenticatedTag extends Tag {
+  val id = 1.toByte
+}
+
+// create a smart constructor
+object Tag {
+  def apply(id: Byte): Tag = id match {
+    case 1 => AuthenticatedTag
+    case _ => Untagged
+  }
+
+
+  // here is a partial function that acts like a finagle filter
+  val authenticated: PartialFunction[Tag, Boolean] = {
+    case AuthenticatedTag => true
+    case _ => false
+  }
+}

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Types.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Types.scala
@@ -6,9 +6,8 @@ trait Types {
   type Size = Int
   type TimeBytes = IndexedSeq[Byte]
   type Entropy = IndexedSeq[Byte]
-  type SecretId = Byte
+  type SecretId = IndexedSeq[Byte]
   type TagId = Byte
   type Payload = IndexedSeq[Byte]
   type Signature = IndexedSeq[Byte]
-
 }

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Types.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Types.scala
@@ -7,6 +7,7 @@ trait Types {
   type TimeBytes = IndexedSeq[Byte]
   type Entropy = IndexedSeq[Byte]
   type SecretId = Byte
+  type TagId = Byte
   type Payload = IndexedSeq[Byte]
   type Signature = IndexedSeq[Byte]
 

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
@@ -94,7 +94,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     }
 
     //  Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
     val cooki = sessionId.asCookie
 
     //  Create request
@@ -127,7 +127,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     val testService = mkTestService[SessionIdRequest] { request => Future.value(Response(Status.NotFound))}
 
     // Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
     val cooki = sessionId.asCookie
 
     // Create request
@@ -147,7 +147,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     }
 
     // Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
     val cooki = sessionId.asCookie
 
     // Create request
@@ -191,7 +191,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     }
 
     //  Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
     val cooki = sessionId.asCookie
 
     //  Create request
@@ -210,7 +210,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
   it should "return a redirect to login UTI, if it fails Session lookup using SessionId" in {
 
     // Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
     val cooki = sessionId.asCookie
 
     // Create request
@@ -231,7 +231,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
 
   it should "propagate the exception thrown by SessionStore.get operation" in {
     // Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
     val cooki = sessionId.asCookie
 
     // Create request
@@ -260,7 +260,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     }
 
     // Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
     val cooki = sessionId.asCookie
 
     // Mock sessionStore
@@ -363,7 +363,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     val testService = mkTestService[SessionIdRequest] { _ => Future.value(Response(Status.Ok)) }
 
     //  Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     //  Create request
     val request = req("enterprise", "/check")
@@ -379,7 +379,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     val testService = mkTestService[SessionIdRequest] { _ => Future.value(Response(Status.Ok)) }
 
     //  Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     //  Create request
     val request = req("enterprise", "/loginConfirm")
@@ -395,7 +395,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     val testService = mkTestService[SessionIdRequest] { _ => Future.value(Response(Status.Ok)) }
 
     //  Allocate and Session
-    val sessionId = sessionid.nextTagged
+    val sessionId = sessionid.next(SessionId.authenticatedTagId)
 
     //  Create request
     val request = req("enterprise", "/ent")
@@ -411,7 +411,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     val testService = mkTestService[SessionIdRequest] { _ => fail("should not get here") }
 
     //  Allocate and Session
-    val sessionId = sessionid.next
+    val sessionId = sessionid.next()
 
     //  Create request
     val request = req("enterprise", "/ent")
@@ -427,7 +427,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     val testService = mkTestService[SessionIdRequest] { _ => fail("should not get here") }
 
     //  Allocate and Session
-    val sessionId = sessionid.nextTagged
+    val sessionId = sessionid.next(SessionId.authenticatedTagId)
 
     //  Create request
     val request = req("enterprise", "/loginConfirm")
@@ -443,7 +443,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     val testService = mkTestService[SessionIdRequest] { _ => fail("should not get here") }
 
     //  Allocate and Session
-    val sessionId = sessionid.nextTagged
+    val sessionId = sessionid.next(SessionId.authenticatedTagId)
 
     //  Create request
     val request = req("enterprise", "/check")

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
@@ -94,7 +94,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     }
 
     //  Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
     val cooki = sessionId.asCookie
 
     //  Create request
@@ -127,7 +127,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     val testService = mkTestService[SessionIdRequest] { request => Future.value(Response(Status.NotFound))}
 
     // Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
     val cooki = sessionId.asCookie
 
     // Create request
@@ -147,7 +147,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     }
 
     // Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
     val cooki = sessionId.asCookie
 
     // Create request
@@ -191,7 +191,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     }
 
     //  Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
     val cooki = sessionId.asCookie
 
     //  Create request
@@ -210,7 +210,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
   it should "return a redirect to login UTI, if it fails Session lookup using SessionId" in {
 
     // Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
     val cooki = sessionId.asCookie
 
     // Create request
@@ -231,7 +231,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
 
   it should "propagate the exception thrown by SessionStore.get operation" in {
     // Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
     val cooki = sessionId.asCookie
 
     // Create request
@@ -260,7 +260,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     }
 
     // Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
     val cooki = sessionId.asCookie
 
     // Mock sessionStore
@@ -363,7 +363,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     val testService = mkTestService[SessionIdRequest] { _ => Future.value(Response(Status.Ok)) }
 
     //  Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     //  Create request
     val request = req("enterprise", "/check")
@@ -379,7 +379,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     val testService = mkTestService[SessionIdRequest] { _ => Future.value(Response(Status.Ok)) }
 
     //  Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     //  Create request
     val request = req("enterprise", "/loginConfirm")
@@ -395,7 +395,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     val testService = mkTestService[SessionIdRequest] { _ => Future.value(Response(Status.Ok)) }
 
     //  Allocate and Session
-    val sessionId = sessionid.next(SessionId.authenticatedTagId)
+    val sessionId = sessionid.authenticated
 
     //  Create request
     val request = req("enterprise", "/ent")
@@ -411,7 +411,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     val testService = mkTestService[SessionIdRequest] { _ => fail("should not get here") }
 
     //  Allocate and Session
-    val sessionId = sessionid.next()
+    val sessionId = sessionid.untagged
 
     //  Create request
     val request = req("enterprise", "/ent")
@@ -427,7 +427,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     val testService = mkTestService[SessionIdRequest] { _ => fail("should not get here") }
 
     //  Allocate and Session
-    val sessionId = sessionid.next(SessionId.authenticatedTagId)
+    val sessionId = sessionid.authenticated
 
     //  Create request
     val request = req("enterprise", "/loginConfirm")
@@ -443,7 +443,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     val testService = mkTestService[SessionIdRequest] { _ => fail("should not get here") }
 
     //  Allocate and Session
-    val sessionId = sessionid.next(SessionId.authenticatedTagId)
+    val sessionId = sessionid.authenticated
 
     //  Create request
     val request = req("enterprise", "/check")

--- a/core/src/test/scala/com/lookout/borderpatrol/test/crypto/cryptoSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/crypto/cryptoSpec.scala
@@ -107,9 +107,9 @@ class cryptoSpec extends BorderPatrolSuite {
   import com.lookout.borderpatrol.test.sessionx.helpers._
 
   val store = EncryptedSessionStore.MemcachedStore(new memcached.MockClient())
-  val strSession = Session("hello").results
-  val intSession = Session(1).results
-  val reqSession = Session(httpx.Request("/api")).results
+  val strSession = Session("hello", false).results
+  val intSession = Session(1, false).results
+  val reqSession = Session(httpx.Request("/api"), false).results
 
   Await.all(
     store.update[Int](intSession),

--- a/core/src/test/scala/com/lookout/borderpatrol/test/crypto/cryptoSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/crypto/cryptoSpec.scala
@@ -107,9 +107,9 @@ class cryptoSpec extends BorderPatrolSuite {
   import com.lookout.borderpatrol.test.sessionx.helpers._
 
   val store = EncryptedSessionStore.MemcachedStore(new memcached.MockClient())
-  val strSession = Session("hello", false).results
-  val intSession = Session(1, false).results
-  val reqSession = Session(httpx.Request("/api"), false).results
+  val strSession = Session("hello").results
+  val intSession = Session(1).results
+  val reqSession = Session(httpx.Request("/api")).results
 
   Await.all(
     store.update[Int](intSession),

--- a/core/src/test/scala/com/lookout/borderpatrol/test/crypto/cryptoSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/crypto/cryptoSpec.scala
@@ -92,7 +92,7 @@ class cryptoSpec extends BorderPatrolSuite {
     def dec[A : Decryptable](id: SessionId, bytes: Array[Byte]): Try[Session[A]] =
       implicitly[Decryptable[A]].decrypt(id, bytes)
 
-    val id = SessionId.next.results
+    val id = SessionId.next().results
     dec[String](id, enc[String](Session(id, "hello"))).success.value should be(Session(id, "hello"))
   }
 
@@ -123,7 +123,7 @@ class cryptoSpec extends BorderPatrolSuite {
   }
 
   it should s"return a None when not present in $store" in {
-    store.get[Int](sessionid.next).results shouldBe None
+    store.get[Int](sessionid.next()).results shouldBe None
   }
 
   it should s"store request sessions $store" in {

--- a/core/src/test/scala/com/lookout/borderpatrol/test/crypto/cryptoSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/crypto/cryptoSpec.scala
@@ -92,7 +92,7 @@ class cryptoSpec extends BorderPatrolSuite {
     def dec[A : Decryptable](id: SessionId, bytes: Array[Byte]): Try[Session[A]] =
       implicitly[Decryptable[A]].decrypt(id, bytes)
 
-    val id = SessionId.next().results
+    val id = SessionId.untagged.results
     dec[String](id, enc[String](Session(id, "hello"))).success.value should be(Session(id, "hello"))
   }
 
@@ -123,7 +123,7 @@ class cryptoSpec extends BorderPatrolSuite {
   }
 
   it should s"return a None when not present in $store" in {
-    store.get[Int](sessionid.next()).results shouldBe None
+    store.get[Int](sessionid.untagged).results shouldBe None
   }
 
   it should s"store request sessions $store" in {

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/EncoderSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/EncoderSpec.scala
@@ -41,9 +41,9 @@ class EncoderSpec extends BorderPatrolSuite {
 
   it should "uphold encoding/decoding identity" in {
     def identity[A](id: SessionId)(implicit ev: SessionIdEncoder[A]): SessionId =
-      ev.decode(ev.encode(id)) getOrElse sessionid.next()
+      ev.decode(ev.encode(id)) getOrElse sessionid.untagged
 
-    val id = sessionid.next()
+    val id = sessionid.untagged
     identity[String](id) should be(id)
   }
 

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/EncoderSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/EncoderSpec.scala
@@ -41,9 +41,9 @@ class EncoderSpec extends BorderPatrolSuite {
 
   it should "uphold encoding/decoding identity" in {
     def identity[A](id: SessionId)(implicit ev: SessionIdEncoder[A]): SessionId =
-      ev.decode(ev.encode(id)) getOrElse sessionid.next
+      ev.decode(ev.encode(id)) getOrElse sessionid.next()
 
-    val id = sessionid.next
+    val id = sessionid.next()
     identity[String](id) should be(id)
   }
 

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionIdSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionIdSpec.scala
@@ -9,7 +9,7 @@ class SessionIdSpec extends BorderPatrolSuite {
   behavior of "SessionId"
 
   it should "create a sessionId with expiry" in {
-    val id = sessionid.next
+    val id = sessionid.next()
     val expiredId = sessionid.expired
 
     id.expired should not be true
@@ -18,14 +18,14 @@ class SessionIdSpec extends BorderPatrolSuite {
   }
 
   it should "convert to and from a string, and cookie" in {
-    val id = sessionid.next
+    val id = sessionid.next()
 
     SessionId.from[String](SessionId.as[String](id)).success.value should be(id)
     SessionId.from[Cookie](SessionId.as[Cookie](id)).success.value should be(id)
   }
 
   it should "create the same signature using the same secret" in {
-    val id = sessionid.next
+    val id = sessionid.next()
     val newSecret = Secret()
 
     id.signWith(newSecret) should be(SessionId.signWith(id, newSecret))
@@ -33,7 +33,7 @@ class SessionIdSpec extends BorderPatrolSuite {
   }
 
   it should "not be derivable from string value if signed with secret not in the store" in {
-    val idWithoutValidSecret = sessionid.next.copy(secret = secrets.invalid)
+    val idWithoutValidSecret = sessionid.next().copy(secret = secrets.invalid)
 
     SessionId.from[String](idWithoutValidSecret.asBase64).failure.exception should be(a [SessionIdError])
   }
@@ -48,8 +48,10 @@ class SessionIdSpec extends BorderPatrolSuite {
   }
 
   it should "create a tagged sessionId" in {
-    val id = sessionid.nextTagged
+    val id = sessionid.next(SessionId.authenticatedTagId)
 
+    println(SessionId.authenticatedTagId)
+    println(id.tagId)
     SessionId.isTagged(id) shouldBe true
   }
 }

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionIdSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionIdSpec.scala
@@ -14,6 +14,7 @@ class SessionIdSpec extends BorderPatrolSuite {
 
     id.expired should not be true
     expiredId.expired shouldBe true
+    SessionId.isTagged(id) shouldBe false
   }
 
   it should "convert to and from a string, and cookie" in {
@@ -46,4 +47,9 @@ class SessionIdSpec extends BorderPatrolSuite {
     SessionId.from[String]("hello world!").failure.exception should be(a [SessionIdError])
   }
 
+  it should "create a tagged sessionId" in {
+    val id = sessionid.nextTagged
+
+    SessionId.isTagged(id) shouldBe true
+  }
 }

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionIdSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionIdSpec.scala
@@ -49,9 +49,6 @@ class SessionIdSpec extends BorderPatrolSuite {
 
   it should "create a tagged sessionId" in {
     val id = sessionid.next(SessionId.authenticatedTagId)
-
-    println(SessionId.authenticatedTagId)
-    println(id.tagId)
     SessionId.isTagged(id) shouldBe true
   }
 }

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionIdSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionIdSpec.scala
@@ -9,23 +9,23 @@ class SessionIdSpec extends BorderPatrolSuite {
   behavior of "SessionId"
 
   it should "create a sessionId with expiry" in {
-    val id = sessionid.next()
+    val id = sessionid.untagged
     val expiredId = sessionid.expired
 
     id.expired should not be true
     expiredId.expired shouldBe true
-    SessionId.isTagged(id) shouldBe false
+    Tag.authenticated(id.tag) shouldBe false
   }
 
   it should "convert to and from a string, and cookie" in {
-    val id = sessionid.next()
+    val id = sessionid.untagged
 
     SessionId.from[String](SessionId.as[String](id)).success.value should be(id)
     SessionId.from[Cookie](SessionId.as[Cookie](id)).success.value should be(id)
   }
 
   it should "create the same signature using the same secret" in {
-    val id = sessionid.next()
+    val id = sessionid.untagged
     val newSecret = Secret()
 
     id.signWith(newSecret) should be(SessionId.signWith(id, newSecret))
@@ -33,7 +33,7 @@ class SessionIdSpec extends BorderPatrolSuite {
   }
 
   it should "not be derivable from string value if signed with secret not in the store" in {
-    val idWithoutValidSecret = sessionid.next().copy(secret = secrets.invalid)
+    val idWithoutValidSecret = sessionid.untagged.copy(secret = secrets.invalid)
 
     SessionId.from[String](idWithoutValidSecret.asBase64).failure.exception should be(a [SessionIdError])
   }
@@ -48,7 +48,7 @@ class SessionIdSpec extends BorderPatrolSuite {
   }
 
   it should "create a tagged sessionId" in {
-    val id = sessionid.next(SessionId.authenticatedTagId)
-    SessionId.isTagged(id) shouldBe true
+    val id = sessionid.authenticated
+    Tag.authenticated(id.tag) shouldBe true
   }
 }

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionSpec.scala
@@ -8,7 +8,7 @@ class SessionSpec extends BorderPatrolSuite {
   behavior of "Session"
 
   it should "expire" in {
-    Session(sessionid.next, 1).expired should be(false)
+    Session(sessionid.next(), 1).expired should be(false)
     Session(sessionid.expired, 1).expired should be(true)
   }
 
@@ -18,7 +18,7 @@ class SessionSpec extends BorderPatrolSuite {
   }
 
   it should "be the same object in memory when equal" in {
-    val id = sessionid.next
+    val id = sessionid.next()
     val data = "session"
     Session(id, data) shouldBe Session(id, data)
     Session(id, "session1") should not be Session(id, "session2")

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionSpec.scala
@@ -8,7 +8,7 @@ class SessionSpec extends BorderPatrolSuite {
   behavior of "Session"
 
   it should "expire" in {
-    Session(sessionid.next(), 1).expired should be(false)
+    Session(sessionid.untagged, 1).expired should be(false)
     Session(sessionid.expired, 1).expired should be(true)
   }
 
@@ -18,7 +18,7 @@ class SessionSpec extends BorderPatrolSuite {
   }
 
   it should "be the same object in memory when equal" in {
-    val id = sessionid.next()
+    val id = sessionid.untagged
     val data = "session"
     Session(id, data) shouldBe Session(id, data)
     Session(id, "session1") should not be Session(id, "session2")

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionStoreSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionStoreSpec.scala
@@ -32,7 +32,7 @@ class SessionStoreSpec extends BorderPatrolSuite {
     }
 
     it should s"return a None when not present in $store" in {
-      store.get[Int](sessionid.next()).results shouldBe None
+      store.get[Int](sessionid.untagged).results shouldBe None
     }
 
     it should s"store request sessions $store" in {

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionStoreSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionStoreSpec.scala
@@ -32,7 +32,7 @@ class SessionStoreSpec extends BorderPatrolSuite {
     }
 
     it should s"return a None when not present in $store" in {
-      store.get[Int](sessionid.next).results shouldBe None
+      store.get[Int](sessionid.next()).results shouldBe None
     }
 
     it should s"store request sessions $store" in {

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/TagSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/TagSpec.scala
@@ -1,0 +1,20 @@
+package com.lookout.borderpatrol.sessionx
+
+import com.lookout.borderpatrol.test._
+
+class TagSpec extends BorderPatrolSuite {
+
+  behavior of "Tag"
+
+  it should "be able to construct appropriate tag objects" in {
+    Tag(1.toByte) should be equals (AuthenticatedTag)
+    Tag(0.toByte) should be equals (Untagged)
+    Tag(5.toByte) should be equals (Untagged)
+  }
+
+  it should "have authenticated return true AuthenticatedTag only" in {
+    Tag.authenticated(AuthenticatedTag) shouldBe true
+    Tag.authenticated(Untagged) shouldBe false
+    Tag.authenticated(Tag(5.toByte)) shouldBe false
+  }
+}

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
@@ -1,6 +1,7 @@
 package com.lookout.borderpatrol.test.sessionx
 
 import com.lookout.borderpatrol.sessionx.SecretStores.InMemorySecretStore
+import com.twitter.bijection.Injection
 import com.twitter.util.{Await, Time}
 
 object helpers {
@@ -10,9 +11,9 @@ object helpers {
     * Common usage of secrets across tests
     */
    object secrets {
-     val current = Secret(1.toByte, Secret.currentExpiry, Entropy(16))
-     val previous = Secret(2.toByte, Time.fromMilliseconds(0), Entropy(16))
-     val invalid = Secret(3.toByte, Time.now, Entropy(16)) // not in store
+     val current = Secret(Injection.short2BigEndian(1), Secret.currentExpiry, Entropy(16))
+     val previous = Secret(Injection.short2BigEndian(2), Time.fromMilliseconds(0), Entropy(16))
+     val invalid = Secret(Injection.short2BigEndian(3), Time.now, Entropy(16)) // not in store
      val secrets = Secrets(current, previous)
    }
    implicit val secretStore = InMemorySecretStore(secrets.secrets)

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
@@ -22,21 +22,18 @@ object helpers {
     */
    object sessionid {
 
-     def next: SessionId =
-       Await.result(SessionId.next)
-
-     def nextTagged: SessionId =
-       Await.result(SessionId.nextTagged)
+     def next(tagId: TagId = SessionId.nullTagId): SessionId =
+       Await.result(SessionId.next(tagId))
 
      def expired: SessionId =
        SessionId(Time.fromMilliseconds(0), Entropy(16), secrets.current, SessionId.nullTagId)
 
      def invalid: SessionId =
-       next.copy(entropy = Entropy(16))
+       next().copy(entropy = Entropy(16))
    }
 
    object sessions {
      def create[A](a: A): Session[A] =
-       Session(sessionid.next, a)
+       Session(sessionid.next(), a)
    }
  }

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
@@ -23,18 +23,21 @@ object helpers {
     */
    object sessionid {
 
-     def next(tagId: TagId = SessionId.nullTagId): SessionId =
-       Await.result(SessionId.next(tagId))
+     def untagged: SessionId =
+       Await.result(SessionId.untagged)
+
+     def authenticated: SessionId =
+       Await.result(SessionId.authenticated)
 
      def expired: SessionId =
-       SessionId(Time.fromMilliseconds(0), Entropy(16), secrets.current, SessionId.nullTagId)
+       SessionId(Time.fromMilliseconds(0), Entropy(16), secrets.current, Untagged)
 
      def invalid: SessionId =
-       next().copy(entropy = Entropy(16))
+       untagged.copy(entropy = Entropy(16))
    }
 
    object sessions {
      def create[A](a: A): Session[A] =
-       Session(sessionid.next(), a)
+       Session(sessionid.untagged, a)
    }
  }

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
@@ -25,8 +25,11 @@ object helpers {
      def next: SessionId =
        Await.result(SessionId.next)
 
+     def nextTagged: SessionId =
+       Await.result(SessionId.nextTagged)
+
      def expired: SessionId =
-       SessionId(Time.fromMilliseconds(0), Entropy(16), secrets.current)
+       SessionId(Time.fromMilliseconds(0), Entropy(16), secrets.current, SessionId.nullTagId)
 
      def invalid: SessionId =
        next.copy(entropy = Entropy(16))

--- a/security/src/test/scala/com/lookout/borderpatrol/test/security/CsrfSpec.scala
+++ b/security/src/test/scala/com/lookout/borderpatrol/test/security/CsrfSpec.scala
@@ -10,8 +10,8 @@ import com.twitter.util.Future
 class CsrfSpec extends BorderPatrolSuite {
   import com.lookout.borderpatrol.test.sessionx.helpers._
 
-  val csrf1 = sessionid.next().asBase64
-  val csrf2 = sessionid.next().asBase64
+  val csrf1 = sessionid.untagged.asBase64
+  val csrf2 = sessionid.untagged.asBase64
 
   val (header, param, cookiename, verified) = ("header", "param", "cookieName", "verified")
   val verify = Verify(InHeader(header), Param(param), CookieName(cookiename), VerifiedHeader(verified))

--- a/security/src/test/scala/com/lookout/borderpatrol/test/security/CsrfSpec.scala
+++ b/security/src/test/scala/com/lookout/borderpatrol/test/security/CsrfSpec.scala
@@ -10,8 +10,8 @@ import com.twitter.util.Future
 class CsrfSpec extends BorderPatrolSuite {
   import com.lookout.borderpatrol.test.sessionx.helpers._
 
-  val csrf1 = sessionid.next.asBase64
-  val csrf2 = sessionid.next.asBase64
+  val csrf1 = sessionid.next().asBase64
+  val csrf2 = sessionid.next().asBase64
 
   val (header, param, cookiename, verified) = ("header", "param", "cookieName", "verified")
   val verify = Verify(InHeader(header), Param(param), CookieName(cookiename), VerifiedHeader(verified))


### PR DESCRIPTION
- Detect if Session (i.e. user) is authenticated or not from the SessionId
  (i.e. added a new byte inside Sessionid)
- If SessionId is authenticated, then any HTTP requests to LoginManager paths
  (i.e. unauthenticated paths) should be redirected to the protected
  Service endpoint (i.e. path of the ServiceIdentifier)
- If SessionId is not authenticated (i.e. not tagged), then any HTTP requests
  to protected endpoint paths, should be redirected to LoginManager path

Fixes #85