### PR TITLE
Add ProtoManager for protocol specific config

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
@@ -108,8 +108,8 @@ object Keymaster {
       extends Filter[SessionIdRequest, Response, SessionIdRequest, Response] {
     def apply(req: SessionIdRequest,
               service: Service[SessionIdRequest, Response]): Future[Response] =
-      (req.req.req.method, req.req.req.path) match {
-        case (Method.Post, loginPath) => service(req)
+      Path(req.req.req.path) match {
+        case req.req.serviceId.loginManager.protoManager.loginConfirm => service(req)
         case _ => binder(BindRequest(req.req.serviceId.loginManager, req.req.req))
       }
   }

--- a/bpConfig.json
+++ b/bpConfig.json
@@ -12,11 +12,27 @@
   "loginManagers": [
     {
       "name": "checkpoint",
-      "path": "/a",
       "identityManager": "keymaster",
       "accessManager": "keymaster",
-      "loginPath": "/signin",
-      "hosts": ["http://localhost:8081"]
+      "proto": {
+        "type": "Internal",
+        "loginConfirm": "/signin",
+        "path": "/a",
+        "hosts": ["http://localhost:8081"]
+      }
+    },
+    {
+      "name": "cascade",
+      "identityManager": "keymaster",
+      "accessManager": "keymaster",
+      "proto": {
+        "type": "OAuth2Code",
+        "loginConfirm": "/signin",
+        "authorizeUrl": "https://login.microsoftonline.com/8ed23968-6ed0-4923-8227-b9edb1a9b5fd/oauth2/authorize",
+        "tokenUrl": "https://login.microsoftonline.com/8ed23968-6ed0-4923-8227-b9edb1a9b5fd/oauth2/token",
+        "clientId": "d3a7f9b0-99cb-4a97-95ff-e2c9d910c46f",
+        "clientSecret": "OfimThKuL0pTHPqUu2NF2U/BZeEu4m17R7wynzZrHmo="
+      }
     }
   ],
   "secretStore": {
@@ -39,10 +55,10 @@
     },
     {
       "hosts": ["http://localhost:8081"],
-      "loginManager": "checkpoint",
-      "subdomain": "admin",
-      "path": "/admin",
-      "name": "admin"
+      "loginManager": "cascade",
+      "subdomain": "cascade",
+      "path": "/top",
+      "name": "cascade"
     }
   ]
 }

--- a/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
@@ -36,7 +36,7 @@ object Binder {
    * It enables dynamic binding to the endpoints (e.g. login service, identity service, etc)
    *
    * Note that BinderContext makes it possible to templatize this code for all the LoginManagerBinder, ManagerBinder,
-   * ServiceIdentigfierBinder, etc, by making calls to methods (e.g. name & hosts) visible in the template.
+   * ServiceIdentifierBinder, etc, by making calls to methods (e.g. name & hosts) visible in the template.
    *
    * @param cache Caches the already established client service
    * @tparam A
@@ -49,10 +49,10 @@ object Binder {
 
         // If its https, use TLS
         val https = !req.hosts.filter(u => u.getProtocol == "https").isEmpty
-        val hostname = req.hosts.map(u => u.getHost()).mkString
+        val hostname = req.hosts.map(u => u.getHost).mkString
 
         // Find CSV of host & ports
-        val hostAndPorts = req.hosts.map(u => u.getAuthority()).mkString(",")
+        val hostAndPorts = req.hosts.map(u => u.getAuthority).mkString(",")
         util.Combinators.tap(
           if (https) Httpx.client.withTls(hostname).newService(hostAndPorts)
           else Httpx.newService(hostAndPorts)
@@ -68,7 +68,7 @@ object Binder {
    */
   implicit object LoginManagerBinderContext extends BinderContext[LoginManager] {
     def name(lm: LoginManager): String = lm.name
-    def hosts(lm: LoginManager): Set[URL] = lm.hosts
+    def hosts(lm: LoginManager): Set[URL] = lm.protoManager.hosts
   }
   implicit object ManagerBinderContext extends BinderContext[Manager] {
     def name(m: Manager): String = m.name

--- a/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
@@ -2,10 +2,9 @@ package com.lookout.borderpatrol
 
 import java.net.URL
 
-import com.twitter.finagle.util.InetSocketAddressUtil
 import com.twitter.finagle.{Httpx, Service}
-import com.twitter.finagle.httpx.{Status, Response, Request}
-import com.twitter.util.{Await, Future}
+import com.twitter.finagle.httpx.{Response, Request}
+import com.twitter.util.Future
 import scala.collection.mutable
 
 /**

--- a/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
@@ -1,10 +1,8 @@
 package com.lookout.borderpatrol
 
 import java.net.URL
-import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.{Status, Response, Request}
+import com.twitter.finagle.httpx.Request
 import com.twitter.finagle.httpx.path.Path
-import com.twitter.util.Future
 
 case class Manager(name: String, path: Path, hosts: Set[URL])
 
@@ -13,7 +11,7 @@ case class LoginManager(name: String, identityManager: Manager, accessManager: M
 
 trait ProtoManager {
   val loginConfirm: Path
-  def redirectLocation(host: String): String
+  def redirectLocation(host: Option[String]): String
   def hosts: Set[URL]
   def isMatchingPath(p: Path): Boolean
   def getOwnedPaths: Set[Path]
@@ -21,19 +19,22 @@ trait ProtoManager {
 
 case class InternalProtoManager(loginConfirm: Path, path: Path, hsts: Set[URL])
     extends ProtoManager {
-  def redirectLocation(host: String): String = path.toString
+  def redirectLocation(host: Option[String]): String = path.toString
   def hosts: Set[URL] = hsts
   def isMatchingPath(p: Path): Boolean =
-    !Set(path, loginConfirm).filter(p.startsWith(_)).isEmpty
+    Set(path, loginConfirm).filter(p.startsWith(_)).nonEmpty
   def getOwnedPaths: Set[Path] = Set(path)
 }
 
 case class OAuth2CodeProtoManager(loginConfirm: Path, authorizeUrl: URL, tokenUrl: URL,
                                   clientId: String, clientSecret: String)
     extends ProtoManager{
-  def redirectLocation(host: String): String =
+  def redirectLocation(host: Option[String]): String = {
+    val hostStr = host.getOrElse(throw new Exception("Host not found in HTTP Request"))
     Request.queryString(authorizeUrl.toString, ("response_type", "code"), ("state", "foo"),
-      ("client_id", clientId), ("redirect_uri", "http://" + host + loginConfirm.toString))
+      ("client_id", clientId),
+      ("redirect_uri", "http://" + hostStr +loginConfirm.toString))
+  }
   def hosts: Set[URL] = Set(authorizeUrl)
   def isMatchingPath(p: Path): Boolean = p.startsWith(loginConfirm)
   def getOwnedPaths: Set[Path] = Set.empty

--- a/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
@@ -1,24 +1,40 @@
 package com.lookout.borderpatrol
 
 import java.net.URL
+import com.twitter.finagle.Service
+import com.twitter.finagle.httpx.{Status, Response, Request}
 import com.twitter.finagle.httpx.path.Path
+import com.twitter.util.Future
 
-/**
- *
- * @param name
- * @param path
- * @param hosts List of URLs to upstream manager
- */
 case class Manager(name: String, path: Path, hosts: Set[URL])
 
-/**
- *
- * @param name
- * @param path
- * @param hosts list of URLs to upstream manager
- * @param loginPath
- * @param identityManager
- * @param accessManager
- */
-case class LoginManager(name: String, path: Path, hosts: Set[URL],
-                        loginPath: Path, identityManager: Manager, accessManager: Manager)
+case class LoginManager(name: String, identityManager: Manager, accessManager: Manager,
+                        protoManager: ProtoManager)
+
+trait ProtoManager {
+  val loginConfirm: Path
+  def redirectLocation(host: String): String
+  def hosts: Set[URL]
+  def isMatchingPath(p: Path): Boolean
+  def getOwnedPaths: Set[Path]
+}
+
+case class InternalProtoManager(loginConfirm: Path, path: Path, hsts: Set[URL])
+    extends ProtoManager {
+  def redirectLocation(host: String): String = path.toString
+  def hosts: Set[URL] = hsts
+  def isMatchingPath(p: Path): Boolean =
+    !Set(path, loginConfirm).filter(p.startsWith(_)).isEmpty
+  def getOwnedPaths: Set[Path] = Set(path)
+}
+
+case class OAuth2CodeProtoManager(loginConfirm: Path, authorizeUrl: URL, tokenUrl: URL,
+                                  clientId: String, clientSecret: String)
+    extends ProtoManager{
+  def redirectLocation(host: String): String =
+    Request.queryString(authorizeUrl.toString, ("response_type", "code"), ("state", "foo"),
+      ("client_id", clientId), ("redirect_uri", "http://" + host + loginConfirm.toString))
+  def hosts: Set[URL] = Set(authorizeUrl)
+  def isMatchingPath(p: Path): Boolean = p.startsWith(loginConfirm)
+  def getOwnedPaths: Set[Path] = Set.empty
+}

--- a/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
@@ -17,9 +17,9 @@ import com.twitter.finagle.httpx.path.Path
 case class ServiceIdentifier(name: String, hosts: Set[URL], path: Path, subdomain: String,
                              loginManager: LoginManager) {
   def isMatchingPath(p: Path): Boolean =
-    isServicePath(p) || isLoginManagerPath(p)
+    isServicePath(p) || loginManager.protoManager.isMatchingPath(p)
   def isServicePath(p: Path): Boolean =
     p.startsWith(path)
   def isLoginManagerPath(p: Path): Boolean =
-    !Set(loginManager.path, loginManager.loginPath).filter(p.startsWith(_)).isEmpty
+    loginManager.protoManager.isMatchingPath(p)
 }

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
@@ -4,7 +4,7 @@ import com.lookout.borderpatrol.util.Combinators.tap
 import com.lookout.borderpatrol.{ServiceIdentifier, ServiceMatcher}
 import com.lookout.borderpatrol.sessionx._
 import com.twitter.finagle.httpx.path.Path
-import com.twitter.finagle.httpx.{Method, Status, Request, Response}
+import com.twitter.finagle.httpx.{Status, Request, Response}
 import com.twitter.finagle.{Service, Filter}
 import com.twitter.util.Future
 import scala.util.{Failure, Success}
@@ -55,8 +55,7 @@ case class SessionIdFilter(store: SessionStore)(implicit secretStore: SecretStor
           session <- Session(req.req)
           _ <- store.update(session)
         } yield tap(Response(Status.Found)) { res =>
-          res.location = req.serviceId.loginManager.protoManager.redirectLocation(
-            req.req.host.getOrElse("lookout.com"))
+          res.location = req.serviceId.loginManager.protoManager.redirectLocation(req.req.host)
           res.addCookie(session.id.asCookie)
         }
     }
@@ -106,8 +105,7 @@ case class BorderService(identityProviderMap: Map[String, Service[SessionIdReque
     redirectTo(req.req.serviceId.path).toFuture
 
   def redirectToLogin(req: SessionIdRequest): Future[Response] =
-    redirectTo(Path(req.req.serviceId.loginManager.protoManager.redirectLocation(
-      req.req.req.host.getOrElse("lookout.com")))).toFuture
+    redirectTo(Path(req.req.serviceId.loginManager.protoManager.redirectLocation(req.req.req.host))).toFuture
 
   def apply(req: SessionIdRequest): Future[Response] =
     req.sessionId.tag match {
@@ -139,8 +137,7 @@ case class IdentityFilter[A : SessionDataEncoder](store: SessionStore)(implicit 
         s <- Session(req.req.req)
         _ <- store.update(s)
       } yield tap(Response(Status.Found)) { res =>
-          res.location = req.req.serviceId.loginManager.protoManager.redirectLocation(
-            req.req.req.host.getOrElse("lookout.com"))
+          res.location = req.req.serviceId.loginManager.protoManager.redirectLocation(req.req.req.host)
           res.addCookie(s.id.asCookie) // add SessionId value as a Cookie
         }
     })

--- a/core/src/test/scala/com/lookout/borderpatrol/test/BinderSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/BinderSpec.scala
@@ -53,7 +53,7 @@ class BinderSpec extends BorderPatrolSuite {
       "localhost:5679", mkTestService[Request]{_ => Response(Status.NotAcceptable).toFuture })
     try {
       val bindReq = BindRequest[LoginManager](checkpointLoginManager,
-        req(checkpointLoginManager.protoManager.redirectLocation("lookout.com")))
+        req(checkpointLoginManager.protoManager.redirectLocation(None)))
       val output = LoginManagerBinder(bindReq)
       Await.result(output).status should be(Status.NotAcceptable)
       /* Make sure client is cached in the cache */

--- a/core/src/test/scala/com/lookout/borderpatrol/test/ServiceMatcherSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/ServiceMatcherSpec.scala
@@ -2,7 +2,7 @@ package com.lookout.borderpatrol.test
 
 import java.net.URL
 
-import com.lookout.borderpatrol.{LoginManager, Manager, ServiceIdentifier, ServiceMatcher}
+import com.lookout.borderpatrol._
 import com.twitter.finagle.httpx.{RequestBuilder, Request}
 import com.twitter.finagle.httpx.path.Path
 
@@ -11,12 +11,17 @@ class ServiceMatcherSpec extends BorderPatrolSuite {
   val urls = Set(new URL("http://localhost:8081"))
   val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), urls)
   val keymasterAccessManager = Manager("keymaster", Path("/accessIssuer"), urls)
-  val checkpointLoginManager = LoginManager("checkpoint", Path("/check"), urls, Path("/loginConfirm"),
-    keymasterIdManager, keymasterAccessManager)
+  val internalProtoManager = InternalProtoManager(Path("/loginConfirm"), Path("/check"), urls)
+  val checkpointLoginManager = LoginManager("checkpoint", keymasterIdManager, keymasterAccessManager,
+    internalProtoManager)
+
   val basicIdManager = Manager("basic", Path("/signin"), urls)
   val basicAccessManager = Manager("basic", Path("/accessin"), urls)
-  val umbrellaLoginManager = LoginManager("umbrella", Path("/umb"), urls, Path("/loginIt"),
-    keymasterIdManager, keymasterAccessManager)
+  val oauth2CodeProtoManager = OAuth2CodeProtoManager(Path("/loginConfirm"),
+    new URL("http://example.com/authorizeUrl"),
+    new URL("http://example.com/tokenUrl"), "clientId", "clientSecret")
+  val umbrellaLoginManager = LoginManager("umbrella", keymasterIdManager, keymasterAccessManager,
+    oauth2CodeProtoManager)
 
   val one = ServiceIdentifier("one", urls, Path("/ent"), "enterprise", checkpointLoginManager)
   val two = ServiceIdentifier("two", urls, Path("/api"), "api", umbrellaLoginManager)

--- a/core/src/test/scala/com/lookout/borderpatrol/test/ServiceMatcherSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/ServiceMatcherSpec.scala
@@ -17,7 +17,7 @@ class ServiceMatcherSpec extends BorderPatrolSuite {
 
   val basicIdManager = Manager("basic", Path("/signin"), urls)
   val basicAccessManager = Manager("basic", Path("/accessin"), urls)
-  val oauth2CodeProtoManager = OAuth2CodeProtoManager(Path("/loginConfirm"),
+  val oauth2CodeProtoManager = OAuth2CodeProtoManager(Path("/loginIt"),
     new URL("http://example.com/authorizeUrl"),
     new URL("http://example.com/tokenUrl"), "clientId", "clientSecret")
   val umbrellaLoginManager = LoginManager("umbrella", keymasterIdManager, keymasterAccessManager,
@@ -55,7 +55,6 @@ class ServiceMatcherSpec extends BorderPatrolSuite {
     serviceMatcher.get(req("api", "/check")) should be(None)
     serviceMatcher.get(req("api", "/loginConfirm")) should be(None)
     serviceMatcher.get(req("api.testdomain", "/apis/test")).value should be(four)
-    serviceMatcher.get(req("api.testdomain", "/umb")).value should be(four)
     serviceMatcher.get(req("api.testdomain", "/loginIt")).value should be(four)
     serviceMatcher.get(req("api.testdomain", "/login")) should be(None)
   }

--- a/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
@@ -30,7 +30,6 @@ import com.lookout.borderpatrol.sessionx._
 import com.lookout.borderpatrol.util.Combinators._
 import com.twitter.io.Buf
 import com.twitter.finagle.httpx.{Method, Request, Response, Status}
-import com.twitter.finagle.httpx.path._
 import com.twitter.finagle.httpx.service.RoutingService
 import com.twitter.finagle.Service
 import com.twitter.util.Future
@@ -119,12 +118,10 @@ object MockService {
     val keymasterIdManager = config.findIdentityManager("keymaster")
     val keymasterAccessManager = config.findAccessManager("keymaster")
 
-    val mockKeymasterPathMap = Map(keymasterAccessManager.path -> mockKeymasterAccessIssuerService,
-      keymasterIdManager.path -> mockKeymasterIdentityService,
-      checkpointLoginManager.path -> mockCheckpointService)
-
-    RoutingService.byMethodAndPathObject {
-      case _ -> path if mockKeymasterPathMap.contains(path) => mockKeymasterPathMap(path)
+    RoutingService.byPathObject {
+      case keymasterAccessManager.path => mockKeymasterAccessIssuerService
+      case keymasterIdManager.path => mockKeymasterIdentityService
+      case path if checkpointLoginManager.protoManager.getOwnedPaths.contains(path) => mockCheckpointService
       case _ => mockUpstreamService
     }
   }

--- a/server/src/test/scala/com/lookout/borderpatrol/server/ServicesSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/ServicesSpec.scala
@@ -3,7 +3,7 @@ package com.lookout.borderpatrol.server
 import java.net.URL
 
 import com.lookout.borderpatrol.sessionx._
-import com.lookout.borderpatrol.{ServiceMatcher, ServiceIdentifier, LoginManager, Manager}
+import com.lookout.borderpatrol._
 import com.lookout.borderpatrol.test.BorderPatrolSuite
 import com.twitter.finagle.httpx.path.Path
 
@@ -15,8 +15,9 @@ class ServicesSpec extends BorderPatrolSuite {
   //  Managers
   val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), urls)
   val keymasterAccessManager = Manager("keymaster", Path("/accessIssuer"), urls)
-  val checkpointLoginManager = LoginManager("checkpoint", Path("/check"), urls, Path("/loginConfirm"),
-    keymasterIdManager, keymasterAccessManager)
+  val internalProtoManager = InternalProtoManager(Path("/loginConfirm"), Path("/check"), urls)
+  val checkpointLoginManager = LoginManager("checkpoint", keymasterIdManager, keymasterAccessManager,
+    internalProtoManager)
 
   // sids
   val one = ServiceIdentifier("one", urls, Path("/ent"), "enterprise", checkpointLoginManager)


### PR DESCRIPTION
- ProtoManager contains seperate config for each protocol
  (such as internal keymaster specific or OAuth2 or SAML)

Fixes #93