### PR TITLE
Add OAuth2 code grant flow support

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Credential.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Credential.scala
@@ -1,0 +1,32 @@
+package com.lookout.borderpatrol.auth.keymaster
+
+import com.lookout.borderpatrol.ServiceIdentifier
+import com.lookout.borderpatrol.util.Combinators._
+import com.twitter.finagle.httpx.{Method, Request}
+
+
+trait Credential {
+  val serviceId: ServiceIdentifier
+  val uniqueId: String
+  def toRequest: Request
+}
+
+case class InternalAuthCredential(uniqueId: String, password: String, serviceId: ServiceIdentifier) extends Credential {
+  def toRequest: Request =
+    tap(Request(Method.Post, serviceId.loginManager.identityManager.path.toString))(req => {
+      req.contentType = "application/x-www-form-urlencoded"
+      req.contentString = Request.queryString(("s", serviceId.name), ("email", uniqueId), ("password", password))
+        .drop(1) /* Drop '?' */
+    })
+}
+
+case class OAuth2CodeCredential(uniqueId: String, subject: String, serviceId: ServiceIdentifier)
+  extends Credential {
+  def toRequest: Request =
+    tap(Request(Method.Post, serviceId.loginManager.identityManager.path.toString))(req => {
+      req.contentType = "application/x-www-form-urlencoded"
+      req.contentString = Request.queryString(("s", serviceId.name), ("external_id", subject),
+        ("ident_provider", serviceId.loginManager.name), ("enterprise", serviceId.subdomain))
+        .drop(1) /* Drop '?' */
+    })
+}

--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterTransform.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterTransform.scala
@@ -1,0 +1,47 @@
+package com.lookout.borderpatrol.auth.keymaster
+
+import com.lookout.borderpatrol.Transform
+import com.lookout.borderpatrol.auth.{IdentityProviderError, SessionIdRequest}
+import com.twitter.finagle.httpx.Status
+import com.twitter.util.Future
+
+object KeymasterTransform {
+  import Tokens._
+
+  implicit val transformBasic: Transform[SessionIdRequest, Future[InternalAuthCredential]] =
+    new Transform[SessionIdRequest, Future[InternalAuthCredential]] {
+      def apply(req: SessionIdRequest): Future[InternalAuthCredential] = {
+        (for {
+          u <- req.req.req.params.get("username")
+          p <- req.req.req.params.get("password")
+        } yield InternalAuthCredential(u, p, req.req.serviceId)) match {
+          case Some(c) => Future.value(c)
+          case None => Future.exception(IdentityProviderError(Status.InternalServerError,
+            "transformBasic: Failed to parse the Request"))
+        }
+      }
+    }
+
+  implicit val transformOAuth2: Transform[SessionIdRequest, Future[OAuth2CodeCredential]] =
+    new Transform[SessionIdRequest, Future[OAuth2CodeCredential]] {
+      def apply(req: SessionIdRequest): Future[OAuth2CodeCredential] = {
+        for {
+          aadToken <- req.req.serviceId.loginManager.protoManager.codeToToken(
+            req.req.req.host, req.req.req.getParam("code")).flatMap(res => res.status match {
+              //  Parse for Tokens if Status.Ok
+              case Status.Ok =>
+                Tokens.derive[AadToken](res.contentString).fold[Future[AadToken]](
+                  err => Future.exception(IdentityProviderError(Status.InternalServerError,
+                    "Failed to parse the AadToken received from OAuth2 Server: " +
+                      s"${req.req.serviceId.loginManager.name}")),
+                  t => Future.value(t)
+                )
+              //  Preserve Response Status code by throwing AccessDenied exceptions
+              case _ => Future.exception(IdentityProviderError(res.status,
+                s"Failed to receive the AadToken from OAuth2 Server: ${req.req.serviceId.loginManager.name}"))
+            })
+          idClaimSet <- Tokens.JwtParse(aadToken.idToken)
+        } yield OAuth2CodeCredential(idClaimSet.getStringClaim("upn"), idClaimSet.getSubject, req.req.serviceId)
+      }
+    }
+}

--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Tokens.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Tokens.scala
@@ -1,7 +1,10 @@
 package com.lookout.borderpatrol.auth.keymaster
 
+import com.lookout.borderpatrol.auth.TokenParsingError
 import com.lookout.borderpatrol.sessionx.{SessionDataError, SessionDataEncoder}
+import com.nimbusds.jwt.{PlainJWT, JWTClaimsSet}
 import com.twitter.io.Buf
+import com.twitter.util.Future
 import io.circe._
 import io.circe.generic.auto._
 import io.circe.syntax._
@@ -26,7 +29,9 @@ case class MasterToken(value: String) extends Token
 /**
  * Service access token to be injected into request to service
  */
-case class ServiceToken(value: String) extends Token
+case class ServiceToken(value: String) extends Token {
+  override def toString: String = value
+}
 
 /**
  * A mapping of service names to service tokens
@@ -58,6 +63,13 @@ case class Tokens(master: MasterToken, services: ServiceTokens) {
   def add(name: String, serviceToken: ServiceToken): Tokens =
     copy(services = this.services.add(name, serviceToken))
 }
+
+/**
+ * AAD token
+ * @param accessToken JWT Access Token
+ * @param idToken JWT ID Token
+ */
+case class AadToken(accessToken: String, idToken: String) extends Token
 
 object Tokens {
 
@@ -117,5 +129,29 @@ object Tokens {
         )
       )
   }
+
+  /**
+   * AadToken Encoder/Decoder
+   */
+  implicit val AadTokenEncoder: Encoder[AadToken] = Encoder.instance {t =>
+    Json.fromFields(Seq(
+      ("access_token", t.accessToken.asJson),
+      ("id_token", t.idToken.asJson)))
+  }
+
+  implicit val AadTokenDecoder: Decoder[AadToken] = Decoder.instance {c =>
+    for {
+      accessToken <- c.downField("access_token").as[String]
+      idToken <- c.downField("id_token").as[String]
+    } yield AadToken(accessToken, idToken)
+  }
+
+  /**
+   * JWT parser wrapper
+   */
+  def JwtParse(tokenStr: String): Future[JWTClaimsSet] =
+    try { Future.value(PlainJWT.parse(tokenStr).getJWTClaimsSet) } catch {
+      case e: Throwable => throw TokenParsingError("Failed to parse JWT token with: " + e.getMessage)
+    }
 }
 

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
@@ -7,9 +7,11 @@ import com.lookout.borderpatrol.auth.keymaster.Keymaster._
 import com.lookout.borderpatrol.auth._
 import com.lookout.borderpatrol.sessionx.SessionStores.MemcachedStore
 import com.lookout.borderpatrol.sessionx._
-import com.lookout.borderpatrol.{ServiceIdentifier, LoginManager, InternalProtoManager, Manager, ServiceMatcher}
+import com.lookout.borderpatrol.{ServiceIdentifier, ServiceMatcher, CommunicationError}
+import com.lookout.borderpatrol.{LoginManager, InternalAuthProtoManager, Manager, OAuth2CodeProtoManager}
 import com.lookout.borderpatrol.test._
 import com.lookout.borderpatrol.util.Combinators.tap
+import com.nimbusds.jwt.{PlainJWT, JWTClaimsSet}
 import com.twitter.finagle.memcached.GetResult
 import com.twitter.finagle.{memcached, Service}
 import com.twitter.finagle.httpx.path.Path
@@ -20,19 +22,32 @@ import com.twitter.util.{Await, Future}
 class KeymasterSpec extends BorderPatrolSuite  {
   import sessionx.helpers.{secretStore => store, _}
   import Tokens._
+  import KeymasterTransform._
 
   val urls = Set(new URL("http://localhost:5678"))
 
   //  Managers
   val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), urls)
   val keymasterAccessManager = Manager("keymaster", Path("/accessIssuer"), urls)
-  val internalProtoManager = InternalProtoManager(Path("/loginConfirm"), Path("/check"), urls)
+  val internalProtoManager = InternalAuthProtoManager(Path("/loginConfirm"), Path("/check"), urls)
   val checkpointLoginManager = LoginManager("checkpoint", keymasterIdManager, keymasterAccessManager,
     internalProtoManager)
+  val oauth2CodeProtoManager = OAuth2CodeProtoManager(Path("/signin"),
+    new URL("http://example.com/authorizeUrl"),
+    new URL("http://localhost:4567/tokenUrl"), "clientId", "clientSecret")
+  val umbrellaLoginManager = LoginManager("ulm", keymasterIdManager, keymasterAccessManager,
+    oauth2CodeProtoManager)
+  val oauth2CodeBadProtoManager = OAuth2CodeProtoManager(Path("/signblew"),
+    new URL("http://localhost:9999/authorizeUrl"),
+    new URL("http://localhost:9999/tokenUrl"), "clientId", "clientSecret")
+  val rainyLoginManager = LoginManager("rlm", keymasterIdManager, keymasterAccessManager,
+    oauth2CodeBadProtoManager)
 
   // sids
   val one = ServiceIdentifier("one", urls, Path("/ent"), "enterprise", checkpointLoginManager)
-  val serviceMatcher = ServiceMatcher(Set(one))
+  val two = ServiceIdentifier("two", urls, Path("/umb"), "umbrella", umbrellaLoginManager)
+  val three = ServiceIdentifier("three", urls, Path("/rain"), "rainy", rainyLoginManager)
+  val serviceMatcher = ServiceMatcher(Set(one, two, three))
   val sessionStore = SessionStores.InMemoryStore
 
   // Request helper
@@ -98,7 +113,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
     // Execute
     val output = KeymasterIdentityProvider(testIdentityManagerBinder)(
-      KeymasterIdentifyReq(Credential("foo", "bar", one)))
+      KeymasterIdentifyReq(InternalAuthCredential("foo", "bar", one)))
 
     // Validate
     Await.result(output).identity should be (Id(tokens))
@@ -109,7 +124,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
     // Execute
     val output = KeymasterIdentityProvider(testIdentityManagerBinder)(
-      KeymasterIdentifyReq(Credential("foo", "bar", one)))
+      KeymasterIdentifyReq(InternalAuthCredential("foo", "bar", one)))
 
     // Validate
     val caught = the [IdentityProviderError] thrownBy {
@@ -129,7 +144,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
 
     // Execute
     val output = KeymasterIdentityProvider(testIdentityManagerBinder)(
-      KeymasterIdentifyReq(Credential("foo", "bar", one)))
+      KeymasterIdentifyReq(InternalAuthCredential("foo", "bar", one)))
 
     // Validate
     val caught = the [IdentityProviderError] thrownBy {
@@ -139,9 +154,171 @@ class KeymasterSpec extends BorderPatrolSuite  {
     caught.status should be (Status.InternalServerError)
   }
 
+  behavior of "transformOAuth2"
+
+  it should "succeed and exchange code for token with OAuth2 IDP" in {
+    val accessToken = new PlainJWT(new JWTClaimsSet.Builder().subject("SomethingAccess").build)
+    val idToken = new PlainJWT(new JWTClaimsSet.Builder().subject("abc123").claim("upn", "test@example.com").build)
+    val aadToken = AadToken(accessToken.serialize, idToken.serialize())
+    val server = com.twitter.finagle.Httpx.serve(
+      "localhost:4567", mkTestService[Request, Response] { req =>
+        assert(req.getParam("code") == "XYZ123")
+        tap(Response(Status.Ok))(res => {
+          res.contentString = AadTokenEncoder(aadToken).toString()
+          res.contentType = "application/json"
+        }).toFuture
+      })
+    try {
+      // Allocate and Session
+      val sessionId = sessionid.untagged
+
+      // Login POST request
+      val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
+
+      // Execute
+      val output = two.loginManager.protoManager.transform[SessionIdRequest, OAuth2CodeCredential](
+        SessionIdRequest(ServiceRequest(loginRequest, two), sessionId))
+
+      // Validate
+      Await.result(output).uniqueId should be("test@example.com")
+      Await.result(output).subject should be("abc123")
+    } finally {
+      server.close()
+    }
+  }
+
+  it should "throw a CommunicationError on failure to talk with OAuth2 IDP" in {
+
+    // Allocate and Session
+    val sessionId = sessionid.untagged
+
+    // Login POST request
+    val loginRequest = req("rainy", "/signblew", ("code" -> "XYZ123"))
+
+    // Execute
+    val output = three.loginManager.protoManager.transform[SessionIdRequest, OAuth2CodeCredential](
+      SessionIdRequest(ServiceRequest(loginRequest, three), sessionId))
+
+    // Validate
+    val caught = the [CommunicationError] thrownBy {
+      Await.result(output)
+    }
+    caught.getMessage should startWith ("An error occurred while talking to: " +
+      "http://localhost:9999/tokenUrl with java.net.ConnectException: Connection refused:")
+  }
+
+  it should "throw an Exception on receiving HTTP request with no host in it" in {
+
+    // Allocate and Session
+    val sessionId = sessionid.untagged
+
+    // Login POST request
+    val loginRequest = Request("/signin", ("code" -> "XYZ123"))
+
+    // Execute
+    // Validate
+    val caught = the [Exception] thrownBy {
+      val output = two.loginManager.protoManager.transform[SessionIdRequest, OAuth2CodeCredential](
+        SessionIdRequest(ServiceRequest(loginRequest, two), sessionId))
+    }
+    caught.getMessage should be ("Host not found in HTTP Request")
+  }
+
+  it should "throw an exception if fails to parse OAuth Server response" in {
+    val server = com.twitter.finagle.Httpx.serve(
+      "localhost:4567", mkTestService[Request, Response] { req =>
+        assert(req.getParam("code") == "XYZ123")
+        tap(Response(Status.Ok))(res => {
+          res.contentString = """{"key":"value"}"""
+          res.contentType = "application/json"
+        }).toFuture
+      })
+    try {
+      // Allocate and Session
+      val sessionId = sessionid.untagged
+
+      // Login POST request
+      val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
+
+      // Execute
+      val output = two.loginManager.protoManager.transform[SessionIdRequest, OAuth2CodeCredential](
+        SessionIdRequest(ServiceRequest(loginRequest, two), sessionId))
+
+      // Validate
+      val caught = the [IdentityProviderError] thrownBy {
+        Await.result(output)
+      }
+      caught.getMessage should be ("Failed to parse the AadToken received from OAuth2 Server: ulm")
+      caught.status should be (Status.InternalServerError)
+    } finally {
+      server.close()
+    }
+  }
+
+  it should "throw an exception if OAuth Server returns an failure status" in {
+    val server = com.twitter.finagle.Httpx.serve(
+      "localhost:4567", mkTestService[Request, Response] { req =>
+        assert(req.getParam("code") == "XYZ123")
+        Response(Status.NotAcceptable).toFuture
+      })
+    try {
+      // Allocate and Session
+      val sessionId = sessionid.untagged
+
+      // Login POST request
+      val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
+
+      // Execute
+      val output = two.loginManager.protoManager.transform[SessionIdRequest, OAuth2CodeCredential](
+        SessionIdRequest(ServiceRequest(loginRequest, two), sessionId))
+
+      // Validate
+      val caught = the [IdentityProviderError] thrownBy {
+        Await.result(output)
+      }
+      caught.getMessage should be ("Failed to receive the AadToken from OAuth2 Server: ulm")
+      caught.status should be (Status.NotAcceptable)
+    } finally {
+      server.close()
+    }
+  }
+
+  it should "throw an IdentityProviderError if it fails to parse ID token" in {
+    val accessToken = new PlainJWT(new JWTClaimsSet.Builder().subject("SomethingAccess").build)
+    val idToken = "stuff" //"""{"key":"value"}"""
+    val aadToken = AadToken(accessToken.serialize(), idToken)
+    val server = com.twitter.finagle.Httpx.serve(
+      "localhost:4567", mkTestService[Request, Response] { req =>
+        assert(req.getParam("code") == "XYZ123")
+        tap(Response(Status.Ok))(res => {
+          res.contentString = AadTokenEncoder(aadToken).toString()
+          res.contentType = "application/json"
+        }).toFuture
+      })
+    try {
+      // Allocate and Session
+      val sessionId = sessionid.untagged
+
+      // Login POST request
+      val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
+
+      // Execute
+      val output = two.loginManager.protoManager.transform[SessionIdRequest, OAuth2CodeCredential](
+        SessionIdRequest(ServiceRequest(loginRequest, two), sessionId))
+
+      // Validate
+      val caught = the [TokenParsingError] thrownBy {
+        Await.result(output)
+      }
+      caught.getMessage should startWith ("Failed to parse JWT token with: Invalid serialized")
+    } finally {
+      server.close()
+    }
+  }
+
   behavior of "KeymasterPostLoginFilter"
 
-  it should "succeed and saves tokens, sends redirect with tokens returned by IDP" in {
+  it should "succeed and saves tokens for internal auth, sends redirect with tokens returned by keymaster IDP" in {
     val testService = mkTestService[IdentifyRequest[Credential], IdentifyResponse[Tokens]] {
       request => Future(KeymasterIdentifyRes(tokens))
     }
@@ -170,6 +347,52 @@ class KeymasterSpec extends BorderPatrolSuite  {
     Await.result(tokensz) should be (tokens)
   }
 
+  it should "succeed and saves tokens for AAD auth, sends redirect with tokens returned by keymaster IDP" in {
+    val accessToken = new PlainJWT(new JWTClaimsSet.Builder().subject("SomethingAccess").build)
+    val idToken = new PlainJWT(new JWTClaimsSet.Builder().subject("abc123").claim("upn", "test@example.com").build)
+    val aadToken = AadToken(accessToken.serialize, idToken.serialize())
+    val server = com.twitter.finagle.Httpx.serve(
+      "localhost:4567", mkTestService[Request, Response] { req =>
+        assert(req.getParam("code") == "XYZ123")
+        tap(Response(Status.Ok))(res => {
+          res.contentString = AadTokenEncoder(aadToken).toString()
+          res.contentType = "application/json"
+        }).toFuture
+      })
+    try {
+      val testService = mkTestService[IdentifyRequest[Credential], IdentifyResponse[Tokens]] {
+        request =>
+          assert(request.credential.uniqueId == "test@example.com")
+          Future.value(KeymasterIdentifyRes(tokens))
+      }
+
+      // Allocate and Session
+      val sessionId = sessionid.untagged
+
+      // Login POST request
+      val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
+
+      // Original request
+      val origReq = req("umbrella", "/umb", ("fake" -> "drake"))
+      sessionStore.update[Request](Session(sessionId, origReq))
+
+      // Execute
+      val output = (KeymasterPostLoginFilter(sessionStore) andThen testService)(
+        SessionIdRequest(ServiceRequest(loginRequest, two), sessionId))
+
+      // Validate
+      Await.result(output).status should be(Status.Found)
+      Await.result(output).location should be equals ("/umb")
+      val returnedSessionId = SessionId.fromResponse(Await.result(output)).toFuture
+      returnedSessionId should not be sessionId
+      val session_d = sessionStore.get[Tokens](Await.result(returnedSessionId))
+      val tokensz = sessionDataFromResponse(Await.result(output))
+      Await.result(tokensz) should be(tokens)
+    } finally {
+      server.close()
+    }
+  }
+
   it should "return BadRequest Status if credentials are not present in the request" in {
     // Allocate and Session
     val sessionId = sessionid.untagged
@@ -182,7 +405,10 @@ class KeymasterSpec extends BorderPatrolSuite  {
       SessionIdRequest(ServiceRequest(loginRequest, one), sessionId))
 
     // Validate
-    Await.result(output).status should be (Status.BadRequest)
+    val caught = the [IdentityProviderError] thrownBy {
+      Await.result(output)
+    }
+    caught.getMessage should equal ("transformBasic: Failed to parse the Request")
   }
 
   it should "return OriginalRequestNotFound if it fails find the original request from sessionStore" in {
@@ -324,7 +550,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     caught.status should be (Status.NotAcceptable)
   }
 
-  behavior of "KeymasterAccessFilter"
+  behavior of "AccessFilter"
 
   it should "succeed and include service token in the request and invoke the REST API of upstream service" in {
     val accessService = mkTestService[AccessRequest[Tokens], AccessResponse[ServiceToken]] {
@@ -345,7 +571,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val request = req("enterprise", "/dang")
 
     // Execute
-    val output = (KeymasterAccessFilter(testSidBinder) andThen accessService)(
+    val output = (AccessFilter[Tokens, ServiceToken](testSidBinder) andThen accessService)(
       AccessIdRequest(SessionIdRequest(ServiceRequest(request, one), sessionId), Id(tokens)))
 
     // Validate
@@ -371,7 +597,7 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val request = req("enterprise", "/dang")
 
     // Execute
-    val output = (KeymasterAccessFilter(testSidBinder) andThen accessService)(
+    val output = (AccessFilter[Tokens, ServiceToken](testSidBinder) andThen accessService)(
       AccessIdRequest(SessionIdRequest(ServiceRequest(request, one), sessionId), Id(tokens)))
 
     // Validate
@@ -397,69 +623,13 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val request = req("enterprise", "/dang")
 
     // Execute
-    val output = (KeymasterAccessFilter(testSidBinder) andThen accessService)(
+    val output = (AccessFilter[Tokens, ServiceToken](testSidBinder) andThen accessService)(
       AccessIdRequest(SessionIdRequest(ServiceRequest(request, one), sessionId), Id(tokens)))
 
     // Validate
     val caught = the [Exception] thrownBy {
       Await.result(output)
     }
-  }
-
-  behavior of "KeymasterMethodMuxLoginFilter"
-
-  it should "succeed and invoke the method on loginManager" in {
-    val testService = mkTestService[SessionIdRequest, Response] { _ => fail("Should not get here") }
-    val testLoginManagerBinder = mkTestLoginManagerBinder { _ => Response(Status.Ok).toFuture }
-
-    // Allocate and Session
-    val sessionId = sessionid.untagged
-
-    // Create request
-    val request = req("enterprise", "/check")
-
-    // Execute
-    val output = (KeymasterMethodMuxLoginFilter(testLoginManagerBinder) andThen testService)(
-      SessionIdRequest(ServiceRequest(request, one), sessionId))
-
-    // Validate
-    Await.result(output).status should be (Status.Ok)
-  }
-
-  it should "succeed and invoke the method on keymaster service" in {
-    val testService = mkTestService[SessionIdRequest, Response] { _ => Response(Status.Ok).toFuture }
-    val testLoginManagerBinder = mkTestLoginManagerBinder { _ => fail("Should not get here") }
-
-    // Allocate and Session
-    val sessionId = sessionid.untagged
-
-    // Create request
-    val request = Request(Method.Post, "/loginConfirm")
-
-    // Execute
-    val output = (KeymasterMethodMuxLoginFilter(testLoginManagerBinder) andThen testService)(
-      SessionIdRequest(ServiceRequest(request, one), sessionId))
-
-    // Validate
-    Await.result(output).status should be (Status.Ok)
-  }
-
-  it should "succeed and invoke the non GET or POST method on keymaster service" in {
-    val testService = mkTestService[SessionIdRequest, Response] { _ => fail("Should not get here") }
-    val testLoginManagerBinder = mkTestLoginManagerBinder { _ => Response(Status.Ok).toFuture }
-
-    // Allocate and Session
-    val sessionId = sessionid.untagged
-
-    // Create request
-    val request = Request(Method.Head, "/ent")
-
-    // Execute
-    val output = (KeymasterMethodMuxLoginFilter(testLoginManagerBinder) andThen testService)(
-      SessionIdRequest(ServiceRequest(request, one), sessionId))
-
-    // Validate
-    Await.result(output).status should be (Status.Ok)
   }
 
   behavior of "keymasterIdentityProviderChain"

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/TokensSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/TokensSpec.scala
@@ -14,6 +14,8 @@ class TokensSpec extends BorderPatrolSuite  {
   val serviceTokens = new ServiceTokens().add("service1", serviceToken1).add("service2", serviceToken2)
   val tokens = Tokens(MasterToken("masterT"), serviceTokens)
   val emptyTokens = Tokens(MasterToken(""), ServiceTokens())
+  val aadToken = AadToken("TestAccessToken", "TestIdToken")
+  val emptyAadToken = AadToken("", "")
 
   behavior of "ServiceTokens"
 
@@ -34,6 +36,16 @@ class TokensSpec extends BorderPatrolSuite  {
     def encodeDecode(toks: Tokens) : Tokens =
       TokensDecoder.decodeJson(TokensEncoder(toks)).fold[Tokens](e => emptyTokens, t => t)
     encodeDecode(tokens) should be (tokens)
+  }
+
+  behavior of "AadToken"
+
+  it should "uphold encoding/decoding AadToken" in {
+    def encodeDecode(toks: AadToken) : AadToken = {
+      val encoded = AadTokenEncoder(toks)
+      AadTokenDecoder.decodeJson(encoded).fold[AadToken](e => emptyAadToken, t => t)
+    }
+    encodeDecode(aadToken) should be (aadToken)
   }
 
   behavior of "SessionDataTokenEncoder"

--- a/bpConfig.json
+++ b/bpConfig.json
@@ -29,7 +29,7 @@
         "type": "OAuth2Code",
         "loginConfirm": "/signin",
         "authorizeUrl": "https://login.microsoftonline.com/8ed23968-6ed0-4923-8227-b9edb1a9b5fd/oauth2/authorize",
-        "tokenUrl": "https://login.microsoftonline.com/8ed23968-6ed0-4923-8227-b9edb1a9b5fd/oauth2/token",
+        "tokenUrl": "https://login.microsoftonline.com:443/8ed23968-6ed0-4923-8227-b9edb1a9b5fd/oauth2/token",
         "clientId": "d3a7f9b0-99cb-4a97-95ff-e2c9d910c46f",
         "clientSecret": "OfimThKuL0pTHPqUu2NF2U/BZeEu4m17R7wynzZrHmo="
       }

--- a/build.sbt
+++ b/build.sbt
@@ -154,7 +154,8 @@ lazy val auth = project
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
-      "io.circe" %% "circe-jawn" % circeVersion
+      "io.circe" %% "circe-jawn" % circeVersion,
+      "com.nimbusds" % "nimbus-jose-jwt" % "4.7"
     )
   )
   .dependsOn(core % "test->test;compile->compile")

--- a/core/src/main/scala/com/lookout/borderpatrol/Errors.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Errors.scala
@@ -1,0 +1,9 @@
+package com.lookout.borderpatrol
+
+class BaseError(val message: String, cause: Throwable) extends Exception(message, cause) {
+  // scalastyle:off null
+  def this(message: String) = this(message, null)
+}
+
+case class CommunicationError(error: String)
+  extends BaseError(s"An error occurred while talking to: $error")

--- a/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
@@ -1,8 +1,9 @@
 package com.lookout.borderpatrol
 
 import java.net.URL
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.httpx.{Method, Status, Response, Request}
 import com.twitter.finagle.httpx.path.Path
+import com.twitter.util.Future
 
 case class Manager(name: String, path: Path, hosts: Set[URL])
 
@@ -15,15 +16,18 @@ trait ProtoManager {
   def hosts: Set[URL]
   def isMatchingPath(p: Path): Boolean
   def getOwnedPaths: Set[Path]
+  def codeToToken(host: Option[String], code: String): Future[Response]
+  def transform[A, B](a: A)(implicit tr: Transform[A, Future[B]]): Future[B] = tr(a)
 }
 
-case class InternalProtoManager(loginConfirm: Path, path: Path, hsts: Set[URL])
+case class InternalAuthProtoManager(loginConfirm: Path, path: Path, hsts: Set[URL])
     extends ProtoManager {
   def redirectLocation(host: Option[String]): String = path.toString
   def hosts: Set[URL] = hsts
   def isMatchingPath(p: Path): Boolean =
     Set(path, loginConfirm).filter(p.startsWith(_)).nonEmpty
   def getOwnedPaths: Set[Path] = Set(path)
+  def codeToToken(host: Option[String], code: String): Future[Response] =  Response(Status.NotAcceptable).toFuture
 }
 
 case class OAuth2CodeProtoManager(loginConfirm: Path, authorizeUrl: URL, tokenUrl: URL,
@@ -32,10 +36,20 @@ case class OAuth2CodeProtoManager(loginConfirm: Path, authorizeUrl: URL, tokenUr
   def redirectLocation(host: Option[String]): String = {
     val hostStr = host.getOrElse(throw new Exception("Host not found in HTTP Request"))
     Request.queryString(authorizeUrl.toString, ("response_type", "code"), ("state", "foo"),
-      ("client_id", clientId),
-      ("redirect_uri", "http://" + hostStr +loginConfirm.toString))
+      ("client_id", clientId), ("redirect_uri", "http://" + hostStr + loginConfirm.toString))
   }
   def hosts: Set[URL] = Set(authorizeUrl)
   def isMatchingPath(p: Path): Boolean = p.startsWith(loginConfirm)
   def getOwnedPaths: Set[Path] = Set.empty
+  def codeToToken(host: Option[String], code: String): Future[Response] = {
+    val hostStr = host.getOrElse(throw new Exception("Host not found in HTTP Request"))
+    val request = util.Combinators.tap(Request(Method.Post, tokenUrl.toString))(re => {
+      re.contentType = "application/x-www-form-urlencoded"
+      re.contentString = Request.queryString(("grant_type", "authorization_code"), ("client_id", clientId),
+        ("code", code), ("redirect_uri", "http://" + hostStr + loginConfirm.toString),
+        ("client_secret", clientSecret), ("resource", "00000002-0000-0000-c000-000000000000"))
+        .drop(1) /* Drop '?' */
+    })
+    BinderBase.connect(tokenUrl.toString, Set(tokenUrl), request)
+  }
 }

--- a/core/src/main/scala/com/lookout/borderpatrol/Transform.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Transform.scala
@@ -1,0 +1,10 @@
+package com.lookout.borderpatrol
+
+/**
+ * Abstraction for those that are directing requests directly to the Identity Provider
+ */
+trait Transform[A, B] {
+  def apply(a: A): B
+}
+
+

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/Errors.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/Errors.scala
@@ -28,3 +28,8 @@ case class IdentityProviderError(status: Status, msg: String) extends AuthError(
  * This exception stores the response code
  */
 case class AccessIssuerError(status: Status, msg: String) extends AuthError(msg, null)
+
+/**
+ * Parsing error
+ */
+case class TokenParsingError(msg: String) extends AuthError(msg, null)

--- a/core/src/test/scala/com/lookout/borderpatrol/test/BinderSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/BinderSpec.scala
@@ -15,7 +15,7 @@ class BinderSpec extends BorderPatrolSuite {
   //  Managers
   val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), urls)
   val keymasterAccessManager = Manager("keymaster", Path("/accessIssuer"), urls)
-  val internalProtoManager = InternalProtoManager(Path("/loginConfirm"), Path("/check"), urls)
+  val internalProtoManager = InternalAuthProtoManager(Path("/loginConfirm"), Path("/check"), urls)
   val checkpointLoginManager = LoginManager("checkpoint", keymasterIdManager, keymasterAccessManager,
     internalProtoManager)
 

--- a/core/src/test/scala/com/lookout/borderpatrol/test/ServiceMatcherSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/ServiceMatcherSpec.scala
@@ -11,7 +11,7 @@ class ServiceMatcherSpec extends BorderPatrolSuite {
   val urls = Set(new URL("http://localhost:8081"))
   val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), urls)
   val keymasterAccessManager = Manager("keymaster", Path("/accessIssuer"), urls)
-  val internalProtoManager = InternalProtoManager(Path("/loginConfirm"), Path("/check"), urls)
+  val internalProtoManager = InternalAuthProtoManager(Path("/loginConfirm"), Path("/check"), urls)
   val checkpointLoginManager = LoginManager("checkpoint", keymasterIdManager, keymasterAccessManager,
     internalProtoManager)
 

--- a/server/src/main/scala/com/lookout/borderpatrol/server/Config.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/Config.scala
@@ -92,7 +92,7 @@ object Config {
    * while decoding the entire ServerConfig due to dependency issues
    */
   implicit val encodeProtoManager: Encoder[ProtoManager] = Encoder.instance {
-    case bpm: InternalProtoManager => Json.fromFields(Seq(
+    case bpm: InternalAuthProtoManager => Json.fromFields(Seq(
       ("type", Json.string("Internal")),
       ("loginConfirm", bpm.loginConfirm.asJson),
       ("path", bpm.path.asJson),
@@ -112,7 +112,7 @@ object Config {
           loginConfirm <- c.downField("loginConfirm").as[Path]
           path <- c.downField("path").as[Path]
           hosts <- c.downField("hosts").as[Set[URL]]
-        } yield InternalProtoManager(loginConfirm, path, hosts)
+        } yield InternalAuthProtoManager(loginConfirm, path, hosts)
       case "OAuth2Code" =>
         for {
           loginConfirm <- c.downField("loginConfirm").as[Path]
@@ -233,7 +233,7 @@ object Config {
    */
   def validateProtoManagerConfig(field: String, lmName: String, protoManager: ProtoManager): Unit = {
     protoManager match {
-      case ipm: InternalProtoManager => validateHostsConfig(field, lmName, protoManager.hosts)
+      case ipm: InternalAuthProtoManager => validateHostsConfig(field, lmName, protoManager.hosts)
       case opm: OAuth2CodeProtoManager =>
     }
   }

--- a/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
@@ -21,7 +21,7 @@ class ConfigSpec extends BorderPatrolSuite {
   val urls = Set(new URL("http://localhost:8081"))
   val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), urls)
   val keymasterAccessManager = Manager("keymaster", Path("/accessIssuer"), urls)
-  val internalProtoManager = InternalProtoManager(Path("/loginConfirm"), Path("/check"), urls)
+  val internalProtoManager = InternalAuthProtoManager(Path("/loginConfirm"), Path("/check"), urls)
   val checkpointLoginManager = LoginManager("checkpoint", keymasterIdManager, keymasterAccessManager,
     internalProtoManager)
 
@@ -267,7 +267,7 @@ class ConfigSpec extends BorderPatrolSuite {
       ("serviceIdentifiers", sids.asJson),
       ("loginManagers", Set(checkpointLoginManager, umbrellaLoginManager,
         LoginManager("checkpoint", keymasterIdManager, keymasterAccessManager,
-          InternalProtoManager(Path("/some"), Path("/some"), urls))).asJson),
+          InternalAuthProtoManager(Path("/some"), Path("/some"), urls))).asJson),
       ("identityManagers", Set(keymasterIdManager).asJson),
       ("accessManagers", Set(keymasterAccessManager).asJson)))
 

--- a/server/src/test/scala/com/lookout/borderpatrol/server/ServicesSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/ServicesSpec.scala
@@ -15,7 +15,7 @@ class ServicesSpec extends BorderPatrolSuite {
   //  Managers
   val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), urls)
   val keymasterAccessManager = Manager("keymaster", Path("/accessIssuer"), urls)
-  val internalProtoManager = InternalProtoManager(Path("/loginConfirm"), Path("/check"), urls)
+  val internalProtoManager = InternalAuthProtoManager(Path("/loginConfirm"), Path("/check"), urls)
   val checkpointLoginManager = LoginManager("checkpoint", keymasterIdManager, keymasterAccessManager,
     internalProtoManager)
 


### PR DESCRIPTION
- redirect to OAuth2 server if user is not authenticated (formatting the redirect url)
- process the received OAuth2 Code
- talk to OAuth2 server and convert Code to Token
- Parse the JWT token and send it to Keymaster for authentication

Fixes #96