### PR TITLE
Add rewritePath to ServiceIdentifier

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
@@ -185,20 +185,21 @@ object Keymaster {
    * @param store
    */
   def keymasterIdentityProviderChain(store: SessionStore)(
-    implicit secretStoreApi: SecretStoreApi, statsReceiver: StatsReceiver): Service[SessionIdRequest, Response] = {
-    LoginManagerFilter(LoginManagerBinder) andThen
-      KeymasterPostLoginFilter(store) andThen
-      KeymasterIdentityProvider(ManagerBinder)
-  }
+    implicit secretStoreApi: SecretStoreApi, statsReceiver: StatsReceiver): Service[SessionIdRequest, Response] =
+      LoginManagerFilter(LoginManagerBinder) andThen
+        KeymasterPostLoginFilter(store) andThen
+        KeymasterIdentityProvider(ManagerBinder)
+
 
   /**
    * Keymaster Access Issuer service Chain
    * @param store
    */
   def keymasterAccessIssuerChain(store: SessionStore)(
-    implicit secretStoreApi: SecretStoreApi, statsReceiver: StatsReceiver): Service[SessionIdRequest, Response] = {
-    IdentityFilter[Tokens](store) andThen
-      AccessFilter[Tokens, ServiceToken](ServiceIdentifierBinder) andThen
-      KeymasterAccessIssuer(ManagerBinder, store)
-  }
+    implicit secretStoreApi: SecretStoreApi, statsReceiver: StatsReceiver): Service[SessionIdRequest, Response] =
+      RewriteFilter() andThen
+        IdentityFilter[Tokens](store) andThen
+        AccessFilter[Tokens, ServiceToken](ServiceIdentifierBinder) andThen
+        KeymasterAccessIssuer(ManagerBinder, store)
+
 }

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
@@ -44,9 +44,9 @@ class KeymasterSpec extends BorderPatrolSuite  {
     oauth2CodeBadProtoManager)
 
   // sids
-  val one = ServiceIdentifier("one", urls, Path("/ent"), "enterprise", checkpointLoginManager)
-  val two = ServiceIdentifier("two", urls, Path("/umb"), "umbrella", umbrellaLoginManager)
-  val three = ServiceIdentifier("three", urls, Path("/rain"), "rainy", rainyLoginManager)
+  val one = ServiceIdentifier("one", urls, Path("/ent"), None, "enterprise", checkpointLoginManager)
+  val two = ServiceIdentifier("two", urls, Path("/umb"), Some(Path("/broken/umb")), "umbrella", umbrellaLoginManager)
+  val three = ServiceIdentifier("three", urls, Path("/rain"), None, "rainy", rainyLoginManager)
   val serviceMatcher = ServiceMatcher(Set(one, two, three))
   val sessionStore = SessionStores.InMemoryStore
 
@@ -559,20 +559,48 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val testSidBinder = mkTestSidBinder {
       request => {
         // Verify service token in the request
-        assert (request.req.headerMap.get("Auth-Token") == Some(serviceToken2.value))
+        assert(request.req.uri == one.path.toString)
+        assert(request.req.headerMap.get("Auth-Token") == Some(serviceToken2.value))
         Response(Status.Ok).toFuture
       }
     }
 
     // Allocate and Session
-    val sessionId = sessionid.untagged
+    val sessionId = sessionid.authenticated
 
     // Create request
-    val request = req("enterprise", "/dang")
+    val request = req("enterprise", "/ent")
 
     // Execute
     val output = (AccessFilter[Tokens, ServiceToken](testSidBinder) andThen accessService)(
       AccessIdRequest(SessionIdRequest(ServiceRequest(request, one), sessionId), Id(tokens)))
+
+    // Validate
+    Await.result(output).status should be (Status.Ok)
+  }
+
+  it should "succeed and include service token in the request and invoke rewritten URL on upstream service" in {
+    val accessService = mkTestService[AccessRequest[Tokens], AccessResponse[ServiceToken]] {
+      request => KeymasterAccessRes(Access(serviceToken2)).toFuture
+    }
+    val testSidBinder = mkTestSidBinder {
+      request => {
+        // Verify service token in the request
+        assert(request.req.uri.startsWith(two.rewritePath.get.toString))
+        assert(request.req.headerMap.get("Auth-Token") == Some(serviceToken2.value))
+        Response(Status.Ok).toFuture
+      }
+    }
+
+    // Allocate and Session
+    val sessionId = sessionid.authenticated
+
+    // Create request
+    val request = req("umbrella", "/umb/some/weird/path")
+
+    // Execute
+    val output = (AccessFilter[Tokens, ServiceToken](testSidBinder) andThen accessService)(
+      AccessIdRequest(SessionIdRequest(ServiceRequest(request, two), sessionId), Id(tokens)))
 
     // Validate
     Await.result(output).status should be (Status.Ok)
@@ -591,10 +619,10 @@ class KeymasterSpec extends BorderPatrolSuite  {
     }
 
     // Allocate and Session
-    val sessionId = sessionid.untagged
+    val sessionId = sessionid.authenticated
 
     // Create request
-    val request = req("enterprise", "/dang")
+    val request = req("enterprise", "/ent/whatever")
 
     // Execute
     val output = (AccessFilter[Tokens, ServiceToken](testSidBinder) andThen accessService)(
@@ -617,10 +645,10 @@ class KeymasterSpec extends BorderPatrolSuite  {
     }
 
     // Allocate and Session
-    val sessionId = sessionid.untagged
+    val sessionId = sessionid.authenticated
 
     // Create request
-    val request = req("enterprise", "/dang")
+    val request = req("enterprise", "/ent/something")
 
     // Execute
     val output = (AccessFilter[Tokens, ServiceToken](testSidBinder) andThen accessService)(

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
@@ -559,7 +559,6 @@ class KeymasterSpec extends BorderPatrolSuite  {
     val testSidBinder = mkTestSidBinder {
       request => {
         // Verify service token in the request
-        assert(request.req.uri == one.path.toString)
         assert(request.req.headerMap.get("Auth-Token") == Some(serviceToken2.value))
         Response(Status.Ok).toFuture
       }
@@ -574,33 +573,6 @@ class KeymasterSpec extends BorderPatrolSuite  {
     // Execute
     val output = (AccessFilter[Tokens, ServiceToken](testSidBinder) andThen accessService)(
       AccessIdRequest(SessionIdRequest(ServiceRequest(request, one), sessionId), Id(tokens)))
-
-    // Validate
-    Await.result(output).status should be (Status.Ok)
-  }
-
-  it should "succeed and include service token in the request and invoke rewritten URL on upstream service" in {
-    val accessService = mkTestService[AccessRequest[Tokens], AccessResponse[ServiceToken]] {
-      request => KeymasterAccessRes(Access(serviceToken2)).toFuture
-    }
-    val testSidBinder = mkTestSidBinder {
-      request => {
-        // Verify service token in the request
-        assert(request.req.uri.startsWith(two.rewritePath.get.toString))
-        assert(request.req.headerMap.get("Auth-Token") == Some(serviceToken2.value))
-        Response(Status.Ok).toFuture
-      }
-    }
-
-    // Allocate and Session
-    val sessionId = sessionid.authenticated
-
-    // Create request
-    val request = req("umbrella", "/umb/some/weird/path")
-
-    // Execute
-    val output = (AccessFilter[Tokens, ServiceToken](testSidBinder) andThen accessService)(
-      AccessIdRequest(SessionIdRequest(ServiceRequest(request, two), sessionId), Id(tokens)))
 
     // Validate
     Await.result(output).status should be (Status.Ok)

--- a/bpConfig.json
+++ b/bpConfig.json
@@ -63,6 +63,7 @@
       "loginManager": "dilli",
       "subdomain": "dilli",
       "path": "/top",
+      "rewritePath": "/internal/top",
       "name": "dilli"
     }
   ]

--- a/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
@@ -11,11 +11,13 @@ import com.twitter.finagle.httpx.path.Path
  * @param name The name that can be used to refer to a [[com.twitter.finagle.Name]]
  * @param hosts The list of URLs to upstream service
  * @param path The external url path prefix that routes to the internal service
+ * @param rewritePath The (optional) internal url path prefix to the internal service. If present,
+ *                    it replaces the external path in the Request URI
  * @param subdomain A default fall-back when path is only `/`
  * @param loginManager The location to send a user when a request to this service is Unauthenticated
  */
-case class ServiceIdentifier(name: String, hosts: Set[URL], path: Path, subdomain: String,
-                             loginManager: LoginManager) {
+case class ServiceIdentifier(name: String, hosts: Set[URL], path: Path, rewritePath: Option[Path],
+                             subdomain: String, loginManager: LoginManager) {
   def isMatchingPath(p: Path): Boolean =
     isServicePath(p) || loginManager.protoManager.isMatchingPath(p)
   def isServicePath(p: Path): Boolean =

--- a/core/src/test/scala/com/lookout/borderpatrol/test/BinderSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/BinderSpec.scala
@@ -20,7 +20,7 @@ class BinderSpec extends BorderPatrolSuite {
     internalProtoManager)
 
   // sids
-  val one = ServiceIdentifier("one", urls, Path("/ent"), "enterprise", checkpointLoginManager)
+  val one = ServiceIdentifier("one", urls, Path("/ent"), None, "enterprise", checkpointLoginManager)
 
   // Request helper
   def req(path: String): Request =

--- a/core/src/test/scala/com/lookout/borderpatrol/test/ServiceMatcherSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/ServiceMatcherSpec.scala
@@ -23,10 +23,10 @@ class ServiceMatcherSpec extends BorderPatrolSuite {
   val umbrellaLoginManager = LoginManager("umbrella", keymasterIdManager, keymasterAccessManager,
     oauth2CodeProtoManager)
 
-  val one = ServiceIdentifier("one", urls, Path("/ent"), "enterprise", checkpointLoginManager)
-  val two = ServiceIdentifier("two", urls, Path("/api"), "api", umbrellaLoginManager)
-  val three = ServiceIdentifier("three", urls, Path("/apis"), "api.subdomain", checkpointLoginManager)
-  val four = ServiceIdentifier("four", urls, Path("/apis/test"), "api.testdomain", umbrellaLoginManager)
+  val one = ServiceIdentifier("one", urls, Path("/ent"), None, "enterprise", checkpointLoginManager)
+  val two = ServiceIdentifier("two", urls, Path("/api"), None, "api", umbrellaLoginManager)
+  val three = ServiceIdentifier("three", urls, Path("/apis"), None, "api.subdomain", checkpointLoginManager)
+  val four = ServiceIdentifier("four", urls, Path("/apis/test"), None, "api.testdomain", umbrellaLoginManager)
   val sids = Set(one, two, three, four)
   val serviceMatcher = ServiceMatcher(sids)
 

--- a/server/src/main/scala/com/lookout/borderpatrol/server/Config.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/Config.scala
@@ -160,6 +160,7 @@ object Config {
       ("name", sid.name.asJson),
       ("hosts", sid.hosts.asJson),
       ("path", sid.path.asJson),
+      ("rewritePath", sid.rewritePath.asJson),
       ("subdomain", sid.subdomain.asJson),
       ("loginManager", sid.loginManager.name.asJson)))
   }
@@ -169,12 +170,13 @@ object Config {
         name <- c.downField("name").as[String]
         hosts <- c.downField("hosts").as[Set[URL]]
         path <- c.downField("path").as[Path]
+        rewritePathOpt <- c.downField("rewritePath").as[Option[Path]]
         subdomain <- c.downField("subdomain").as[String]
         lmName <- c.downField("loginManager").as[String]
         lm <- Xor.fromOption(lms.get(lmName),
           DecodingFailure(s"No LoginManager $lmName found: ", c.history)
         )
-      } yield ServiceIdentifier(name, hosts, path, subdomain, lm)
+      } yield ServiceIdentifier(name, hosts, path, rewritePathOpt, subdomain, lm)
     }
 
   /**

--- a/server/src/test/scala/com/lookout/borderpatrol/server/ServicesSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/ServicesSpec.scala
@@ -4,7 +4,6 @@ import java.net.URL
 
 import com.lookout.borderpatrol.sessionx._
 import com.lookout.borderpatrol._
-import com.lookout.borderpatrol.test.sessionx.helpers._
 import com.lookout.borderpatrol.test.{sessionx, BorderPatrolSuite}
 import com.twitter.finagle.httpx.path.Path
 
@@ -22,7 +21,7 @@ class ServicesSpec extends BorderPatrolSuite {
     internalProtoManager)
 
   // sids
-  val one = ServiceIdentifier("one", urls, Path("/ent"), "enterprise", checkpointLoginManager)
+  val one = ServiceIdentifier("one", urls, Path("/ent"), None, "enterprise", checkpointLoginManager)
   val sids = Set(one)
   val serviceMatcher = ServiceMatcher(sids)
 


### PR DESCRIPTION
Its an optional parameter

If present, it will replaces the external path configuration in
ServiceIdentifier with the rewritePath configuration in the ServiceIdentifier

Fixes #103