### PR TITLE
Add logout support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.1.4-SNAPSHOT"
+lazy val Version = "0.1.5-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
@@ -22,8 +22,7 @@ case class InternalAuthProtoManager(loginConfirm: Path, path: Path, hsts: Set[UR
     extends ProtoManager {
   def redirectLocation(host: Option[String]): String = path.toString
   def hosts: Set[URL] = hsts
-  def isMatchingPath(p: Path): Boolean =
-    Set(path, loginConfirm).filter(p.startsWith(_)).nonEmpty
+  def isMatchingPath(p: Path): Boolean = Set(path, loginConfirm, Path("/logout")).filter(p.startsWith(_)).nonEmpty
   def getOwnedPaths: Set[Path] = Set(path)
 }
 
@@ -36,7 +35,7 @@ case class OAuth2CodeProtoManager(loginConfirm: Path, authorizeUrl: URL, tokenUr
       ("client_id", clientId), ("redirect_uri", "http://" + hostStr + loginConfirm.toString))
   }
   def hosts: Set[URL] = Set(authorizeUrl)
-  def isMatchingPath(p: Path): Boolean = p.startsWith(loginConfirm)
+  def isMatchingPath(p: Path): Boolean = Set(loginConfirm, Path("/logout")).filter(p.startsWith(_)).nonEmpty
   def getOwnedPaths: Set[Path] = Set.empty
   def codeToToken(host: Option[String], code: String): Future[Response] = {
     val hostStr = host.getOrElse(throw new Exception("Host not found in HTTP Request"))

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
@@ -158,6 +158,36 @@ case class BorderService(identityProviderMap: Map[String, Service[SessionIdReque
 }
 
 /**
+ * Logout Service
+ * - Deletes the session
+ * - sets the empty cookie in response
+ * - redirects to default service path
+ */
+case class LogoutService(store: SessionStore)(implicit secretStore: SecretStoreApi)
+  extends Service[ServiceRequest, Response] {
+  private[this] val log = Logger.getLogger(getClass.getSimpleName)
+
+  def apply(req: ServiceRequest): Future[Response] = {
+    SessionId.fromRequest(req.req) match {
+      case Success(sid) => {
+        log.log(Level.DEBUG, s"Logging out Session: ${sid.toLogIdString}")
+        store.delete(sid)
+        tap(Response(Status.Found)) { res =>
+          res.location = req.customerId.defaultServiceId.path.toString
+          res.addCookie(SessionId.toCookie(sid, true))
+          log.log(Level.DEBUG, s"W/ Session: Redirecting to default service path: ${res.location}")
+        }.toFuture
+      }
+      case Failure(e) =>
+        tap(Response(Status.Found)) { res =>
+          res.location = req.customerId.defaultServiceId.path.toString
+          log.log(Level.DEBUG, s"W/O Session: Redirecting to default service path: ${res.location}")
+        }.toFuture
+    }
+  }
+}
+
+/**
  * Determines the identity of the requester, if no identity it responds with a redirect to the login page for that
  * service
  */

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Encoder.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Encoder.scala
@@ -166,7 +166,7 @@ object SessionIdEncoder {
    * [[com.twitter.finagle.httpx.Cookie Cookie]]
    */
   implicit def encodeCookie(implicit secretStoreApi: SecretStoreApi): SessionIdEncoder[Cookie] = SessionIdEncoder(
-    id => new Cookie("border_session", SessionId.toBase64(id)),
+    id => id.asCookie,
     cookie => SessionIdInjections.str2SessionId(cookie.value)
   )
 

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/SessionId.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/SessionId.scala
@@ -94,11 +94,12 @@ object SessionId {
   def toBase64(sessionId: SessionId): String =
     Base64StringEncoder.encode(toArray(sessionId))
 
-  def toCookie(sessionId: SessionId): Cookie =
+  def toCookie(sessionId: SessionId, expired: Boolean = false): Cookie =
     tap(new Cookie("border_session", toBase64(sessionId))) { cookie =>
       cookie.path = "/"
       cookie.httpOnly = true
-      cookie.maxAge = Time.now.until(sessionId.expires)
+      cookie.isDiscard = expired
+      cookie.maxAge = if (expired) Duration(0, TimeUnit.SECONDS) else Time.now.until(sessionId.expires)
     }
 
   def fromCookie(cooki: Option[Cookie])(implicit ev: SecretStoreApi): Try[SessionId] =

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/SessionId.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/SessionId.scala
@@ -94,12 +94,19 @@ object SessionId {
   def toBase64(sessionId: SessionId): String =
     Base64StringEncoder.encode(toArray(sessionId))
 
-  def toCookie(sessionId: SessionId, expired: Boolean = false): Cookie =
+  def toCookie(sessionId: SessionId): Cookie =
     tap(new Cookie("border_session", toBase64(sessionId))) { cookie =>
       cookie.path = "/"
       cookie.httpOnly = true
-      cookie.isDiscard = expired
-      cookie.maxAge = if (expired) Duration(0, TimeUnit.SECONDS) else Time.now.until(sessionId.expires)
+      cookie.maxAge = Time.now.until(sessionId.expires)
+    }
+
+  def toExpiredCookie(): Cookie =
+    tap(new Cookie("border_session", "")) { cookie =>
+      cookie.path = "/"
+      cookie.httpOnly = true
+      cookie.isDiscard = true
+      cookie.maxAge = Duration(0, TimeUnit.SECONDS)
     }
 
   def fromCookie(cooki: Option[Cookie])(implicit ev: SecretStoreApi): Try[SessionId] =

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
@@ -671,8 +671,8 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     // Validate
     Await.result(output).status should be (Status.Found)
     Await.result(output).location.get should be (cust1.defaultServiceId.path.toString)
-    Await.result(output).cookies.get("border_session").get.value should be ("")
-    Await.result(output).cookies.get("border_session").get.isDiscard should be (true)
+    Await.result(output).cookies.get(SessionId.cookieName).get.value should be ("")
+    Await.result(output).cookies.get(SessionId.cookieName).get.isDiscard should be (true)
     Await.result(sessionStore.get[Int](sessionId)) should be (None)
   }
 
@@ -686,7 +686,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     // Validate
     Await.result(output).status should be (Status.Found)
     Await.result(output).location.get should be (cust1.defaultServiceId.path.toString)
-    Await.result(output).cookies.get("border_session").get.value should be ("")
-    Await.result(output).cookies.get("border_session").get.isDiscard should be (true)
+    Await.result(output).cookies.get(SessionId.cookieName).get.value should be ("")
+    Await.result(output).cookies.get(SessionId.cookieName).get.isDiscard should be (true)
   }
 }

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
@@ -671,6 +671,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     // Validate
     Await.result(output).status should be (Status.Found)
     Await.result(output).location.get should be (cust1.defaultServiceId.path.toString)
+    Await.result(output).cookies.get("border_session").get.value should be ("")
     Await.result(output).cookies.get("border_session").get.isDiscard should be (true)
     Await.result(sessionStore.get[Int](sessionId)) should be (None)
   }
@@ -685,6 +686,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     // Validate
     Await.result(output).status should be (Status.Found)
     Await.result(output).location.get should be (cust1.defaultServiceId.path.toString)
-    Await.result(output).cookies.get("border_session") should be (None)
+    Await.result(output).cookies.get("border_session").get.value should be ("")
+    Await.result(output).cookies.get("border_session").get.isDiscard should be (true)
   }
 }


### PR DESCRIPTION
- simply listens for logouts on a hardcoded path `/logout`
- if Request contains the cookie for `SessionId`, then the Session is looked up and removed from the SessionStore
- The client is redirected to default Service Id dictated by the subdomain (i.e. configured in customerIdentifier)


Fixes #114