### PR TITLE
After login return 404 for unknown resources

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/package.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/package.scala
@@ -5,7 +5,7 @@ package com.lookout.borderpatrol.auth
  *
  * The composition of these filters should work, e.g.:
  *
- * val bpFilter = ServiceFilter andThen SessionIdFilter
+ * val bpFilter = CustomerIdFilter andThen SessionIdFilter
  * val loginFilters = bpFilter andThen ...
  * val authFilters = bpFilter andThen IdentityFilter(???) andThen AccessFilter(???)
  */

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
@@ -68,7 +68,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     val loginRequest = req("enterprise", "/loginConfirm", "username" -> "foo", "password" -> "bar")
 
     //  Request
-    val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust1, one), sessionId)
+    val sessionIdRequest = SessionIdRequest(loginRequest, cust1, one, sessionId)
 
     // Execute
     val output = KeymasterIdentityProvider(testIdentityManagerBinder).apply(
@@ -88,7 +88,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
     //  Request
-    val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust2, two), sessionId)
+    val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
 
     // Execute
     val output = KeymasterIdentityProvider(testIdentityManagerBinder).apply(
@@ -117,7 +117,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     val loginRequest = req("enterprise", "/loginConfirm", "username" -> "foo", "password" -> "bar")
 
     //  Request
-    val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust1, one), sessionId)
+    val sessionIdRequest = SessionIdRequest(loginRequest, cust1, one, sessionId)
 
     // Execute
     val output = KeymasterIdentityProvider(testIdentityManagerBinder).apply(
@@ -153,7 +153,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Execute
     val output = (KeymasterTransformFilter(oAuth2CodeVerify) andThen testService)(
-      SessionIdRequest(ServiceRequest(loginRequest, cust1, one), sessionId))
+      SessionIdRequest(loginRequest, cust1, one, sessionId))
 
     // Validate
     Await.result(output).status should be(Status.Ok)
@@ -181,7 +181,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
     //  Request
-    val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust2, two), sessionId)
+    val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
 
     // Mock the oAuth2 verifier
     val mockVerify = mock[OAuth2CodeVerify]
@@ -206,7 +206,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Execute
     val output = (KeymasterTransformFilter(oAuth2CodeVerify) andThen testService)(
-      SessionIdRequest(ServiceRequest(loginRequest, cust1, one), sessionId))
+      SessionIdRequest(loginRequest, cust1, one, sessionId))
 
     // Validate
     val caught = the [IdentityProviderError] thrownBy {
@@ -239,7 +239,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Execute
     val output = (KeymasterPostLoginFilter(sessionStore) andThen testService)(
-      KeymasterIdentifyReq(SessionIdRequest(ServiceRequest(loginRequest, cust1, one), sessionId), credential))
+      KeymasterIdentifyReq(SessionIdRequest(loginRequest, cust1, one, sessionId), credential))
 
     // Validate
     Await.result(output).status should be (Status.Found)
@@ -273,7 +273,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Execute
     val output = (KeymasterPostLoginFilter(sessionStore) andThen testService)(
-      KeymasterIdentifyReq(SessionIdRequest(ServiceRequest(loginRequest, cust2, two), sessionId), credential))
+      KeymasterIdentifyReq(SessionIdRequest(loginRequest, cust2, two, sessionId), credential))
 
     // Validate
     Await.result(output).status should be(Status.Found)
@@ -297,7 +297,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Execute
     val output = (KeymasterPostLoginFilter(sessionStore) andThen keymasterLoginFilterTestService)(
-      KeymasterIdentifyReq(SessionIdRequest(ServiceRequest(loginRequest, cust1, one), sessionId), credential))
+      KeymasterIdentifyReq(SessionIdRequest(loginRequest, cust1, one, sessionId), credential))
 
     // Validate
     val caught = the [OriginalRequestNotFound] thrownBy {
@@ -327,7 +327,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Execute
     val output = (KeymasterPostLoginFilter(mockSessionStore) andThen keymasterLoginFilterTestService)(
-      KeymasterIdentifyReq(SessionIdRequest(ServiceRequest(loginRequest, cust1, one), sessionId), credential))
+      KeymasterIdentifyReq(SessionIdRequest(loginRequest, cust1, one, sessionId), credential))
 
     // Validate
     val caught = the [Exception] thrownBy {
@@ -452,7 +452,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Execute
     val output = (AccessFilter[Tokens, ServiceToken](testSidBinder) andThen accessService)(
-      AccessIdRequest(SessionIdRequest(ServiceRequest(request, cust1, one), sessionId), Id(tokens)))
+      AccessIdRequest(request, cust1, one, sessionId, Id(tokens)))
 
     // Validate
     Await.result(output).status should be (Status.Ok)
@@ -478,7 +478,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Execute
     val output = (AccessFilter[Tokens, ServiceToken](testSidBinder) andThen accessService)(
-      AccessIdRequest(SessionIdRequest(ServiceRequest(request, cust1, one), sessionId), Id(tokens)))
+      AccessIdRequest(request, cust1, one, sessionId, Id(tokens)))
 
     // Validate
     Await.result(output).status should be (Status.NotFound)
@@ -504,7 +504,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Execute
     val output = (AccessFilter[Tokens, ServiceToken](testSidBinder) andThen accessService)(
-      AccessIdRequest(SessionIdRequest(ServiceRequest(request, cust1, one), sessionId), Id(tokens)))
+      AccessIdRequest(request, cust1, one, sessionId, Id(tokens)))
 
     // Validate
     val caught = the [Exception] thrownBy {
@@ -535,7 +535,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
       // Execute
       val output = keymasterIdentityProviderChain(sessionStore).apply(
-        SessionIdRequest(ServiceRequest(loginRequest, cust1, one), sessionId))
+        SessionIdRequest(loginRequest, cust1, one, sessionId))
 
       // Validate
       Await.result(output).status should be(Status.Ok)
@@ -569,7 +569,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
       // Execute
       val output = keymasterIdentityProviderChain(sessionStore).apply(
-        SessionIdRequest(ServiceRequest(loginRequest, cust1, one), sessionId))
+        SessionIdRequest(loginRequest, cust1, one, sessionId))
 
       // Validate
       Await.result(output).status should be(Status.Found)
@@ -602,7 +602,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
       // Execute
       val output = keymasterAccessIssuerChain(sessionStore).apply(
-        SessionIdRequest(ServiceRequest(origReq, cust1, one), sessionId))
+        SessionIdRequest(origReq, cust1, one, sessionId))
 
       // Validate
       Await.result(output).status should be(Status.Ok)

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
@@ -68,7 +68,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     val loginRequest = req("enterprise", "/loginConfirm", "username" -> "foo", "password" -> "bar")
 
     //  Request
-    val sessionIdRequest = SessionIdRequest(loginRequest, cust1, one, sessionId)
+    val sessionIdRequest = BorderRequest(loginRequest, cust1, one, sessionId)
 
     // Execute
     val output = KeymasterIdentityProvider(testIdentityManagerBinder).apply(
@@ -88,7 +88,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
     //  Request
-    val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
+    val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
 
     // Execute
     val output = KeymasterIdentityProvider(testIdentityManagerBinder).apply(
@@ -117,7 +117,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     val loginRequest = req("enterprise", "/loginConfirm", "username" -> "foo", "password" -> "bar")
 
     //  Request
-    val sessionIdRequest = SessionIdRequest(loginRequest, cust1, one, sessionId)
+    val sessionIdRequest = BorderRequest(loginRequest, cust1, one, sessionId)
 
     // Execute
     val output = KeymasterIdentityProvider(testIdentityManagerBinder).apply(
@@ -137,7 +137,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     val testService = mkTestService[KeymasterIdentifyReq, Response] {
       req =>
         assert(req.credential.serviceId == one)
-        assert(req.req.serviceId == one)
+        assert(req.serviceId == one)
         req.credential match {
           case a: InternalAuthCredential => assert(a.uniqueId == "test@example.com")
           case _ => assert(false)
@@ -153,7 +153,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Execute
     val output = (KeymasterTransformFilter(oAuth2CodeVerify) andThen testService)(
-      SessionIdRequest(loginRequest, cust1, one, sessionId))
+      BorderRequest(loginRequest, cust1, one, sessionId))
 
     // Validate
     Await.result(output).status should be(Status.Ok)
@@ -163,7 +163,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     val testService = mkTestService[KeymasterIdentifyReq, Response] {
       req =>
         assert(req.credential.serviceId == two)
-        assert(req.req.serviceId == two)
+        assert(req.serviceId == two)
         req.credential match {
           case a: OAuth2CodeCredential => assert(a.uniqueId == "test@example.com")
           case _ => assert(false)
@@ -181,7 +181,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
     //  Request
-    val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
+    val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
 
     // Mock the oAuth2 verifier
     val mockVerify = mock[OAuth2CodeVerify]
@@ -206,7 +206,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Execute
     val output = (KeymasterTransformFilter(oAuth2CodeVerify) andThen testService)(
-      SessionIdRequest(loginRequest, cust1, one, sessionId))
+      BorderRequest(loginRequest, cust1, one, sessionId))
 
     // Validate
     val caught = the [IdentityProviderError] thrownBy {
@@ -239,7 +239,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Execute
     val output = (KeymasterPostLoginFilter(sessionStore) andThen testService)(
-      KeymasterIdentifyReq(SessionIdRequest(loginRequest, cust1, one, sessionId), credential))
+      KeymasterIdentifyReq(BorderRequest(loginRequest, cust1, one, sessionId), credential))
 
     // Validate
     Await.result(output).status should be (Status.Found)
@@ -273,7 +273,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Execute
     val output = (KeymasterPostLoginFilter(sessionStore) andThen testService)(
-      KeymasterIdentifyReq(SessionIdRequest(loginRequest, cust2, two, sessionId), credential))
+      KeymasterIdentifyReq(BorderRequest(loginRequest, cust2, two, sessionId), credential))
 
     // Validate
     Await.result(output).status should be(Status.Found)
@@ -297,7 +297,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Execute
     val output = (KeymasterPostLoginFilter(sessionStore) andThen keymasterLoginFilterTestService)(
-      KeymasterIdentifyReq(SessionIdRequest(loginRequest, cust1, one, sessionId), credential))
+      KeymasterIdentifyReq(BorderRequest(loginRequest, cust1, one, sessionId), credential))
 
     // Validate
     val caught = the [OriginalRequestNotFound] thrownBy {
@@ -327,7 +327,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Execute
     val output = (KeymasterPostLoginFilter(mockSessionStore) andThen keymasterLoginFilterTestService)(
-      KeymasterIdentifyReq(SessionIdRequest(loginRequest, cust1, one, sessionId), credential))
+      KeymasterIdentifyReq(BorderRequest(loginRequest, cust1, one, sessionId), credential))
 
     // Validate
     val caught = the [Exception] thrownBy {
@@ -535,7 +535,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
       // Execute
       val output = keymasterIdentityProviderChain(sessionStore).apply(
-        SessionIdRequest(loginRequest, cust1, one, sessionId))
+        BorderRequest(loginRequest, cust1, one, sessionId))
 
       // Validate
       Await.result(output).status should be(Status.Ok)
@@ -569,7 +569,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
       // Execute
       val output = keymasterIdentityProviderChain(sessionStore).apply(
-        SessionIdRequest(loginRequest, cust1, one, sessionId))
+        BorderRequest(loginRequest, cust1, one, sessionId))
 
       // Validate
       Await.result(output).status should be(Status.Found)
@@ -602,7 +602,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
 
       // Execute
       val output = keymasterAccessIssuerChain(sessionStore).apply(
-        SessionIdRequest(origReq, cust1, one, sessionId))
+        BorderRequest(origReq, cust1, one, sessionId))
 
       // Validate
       Await.result(output).status should be(Status.Ok)

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/OAuth2.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/OAuth2.scala
@@ -150,7 +150,7 @@ object OAuth2 {
      * @param protoManager
      * @return
      */
-    def codeToClaimsSet(req: SessionIdRequest, protoManager: OAuth2CodeProtoManager): Future[JWTClaimsSet] = {
+    def codeToClaimsSet(req: BorderRequest, protoManager: OAuth2CodeProtoManager): Future[JWTClaimsSet] = {
       for {
         aadToken <- protoManager.codeToToken(
           req.req.host, req.req.getParam("code")).flatMap(res => res.status match {

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
@@ -170,7 +170,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
       // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust2, two), sessionId)
+      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -222,7 +222,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
       // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust2, two), sessionId)
+      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -261,7 +261,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
       // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust2, two), sessionId)
+      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
 
       // Add certificate
       val oAuth2CodeVerify = new MockOAuth2CodeVerify()
@@ -287,7 +287,7 @@ class OAuth2Spec extends BorderPatrolSuite {
     val loginRequest = req("rainy", "/signblew", ("code" -> "XYZ123"))
 
     // SessionIdRequest
-    val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust3, three), sessionId)
+    val sessionIdRequest = SessionIdRequest(loginRequest, cust3, three, sessionId)
 
     // Execute
     val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeBadProtoManager)
@@ -309,7 +309,7 @@ class OAuth2Spec extends BorderPatrolSuite {
     val loginRequest = Request("/signin", ("code" -> "XYZ123"))
 
     // SessionIdRequest
-    val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust2, two), sessionId)
+    val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
 
     // Validate
     val caught = the[Exception] thrownBy {
@@ -337,7 +337,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
       // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust2, two), sessionId)
+      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -367,7 +367,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
       // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust2, two), sessionId)
+      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -402,7 +402,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
       // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust2, two), sessionId)
+      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -436,7 +436,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
       // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust2, two), sessionId)
+      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -474,7 +474,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
       // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust2, two), sessionId)
+      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -527,7 +527,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
       // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust2, two), sessionId)
+      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -579,7 +579,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
       // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust2, two), sessionId)
+      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -617,7 +617,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
       // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(ServiceRequest(loginRequest, cust2, two), sessionId)
+      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
 
       // Add certificate
       val oAuth2CodeVerify = new MockOAuth2CodeVerify()

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
@@ -169,8 +169,8 @@ class OAuth2Spec extends BorderPatrolSuite {
       // Login POST request
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
-      // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
+      // BorderRequest
+      val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -221,8 +221,8 @@ class OAuth2Spec extends BorderPatrolSuite {
       // Login POST request
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
-      // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
+      // BorderRequest
+      val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -260,8 +260,8 @@ class OAuth2Spec extends BorderPatrolSuite {
       // Login POST request
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
-      // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
+      // BorderRequest
+      val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
 
       // Add certificate
       val oAuth2CodeVerify = new MockOAuth2CodeVerify()
@@ -286,8 +286,8 @@ class OAuth2Spec extends BorderPatrolSuite {
     // Login POST request
     val loginRequest = req("rainy", "/signblew", ("code" -> "XYZ123"))
 
-    // SessionIdRequest
-    val sessionIdRequest = SessionIdRequest(loginRequest, cust3, three, sessionId)
+    // BorderRequest
+    val sessionIdRequest = BorderRequest(loginRequest, cust3, three, sessionId)
 
     // Execute
     val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeBadProtoManager)
@@ -308,8 +308,8 @@ class OAuth2Spec extends BorderPatrolSuite {
     // Login POST request
     val loginRequest = Request("/signin", ("code" -> "XYZ123"))
 
-    // SessionIdRequest
-    val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
+    // BorderRequest
+    val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
 
     // Validate
     val caught = the[Exception] thrownBy {
@@ -336,8 +336,8 @@ class OAuth2Spec extends BorderPatrolSuite {
       // Login POST request
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
-      // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
+      // BorderRequest
+      val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -366,8 +366,8 @@ class OAuth2Spec extends BorderPatrolSuite {
       // Login POST request
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
-      // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
+      // BorderRequest
+      val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -401,8 +401,8 @@ class OAuth2Spec extends BorderPatrolSuite {
       // Login POST request
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
-      // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
+      // BorderRequest
+      val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -435,8 +435,8 @@ class OAuth2Spec extends BorderPatrolSuite {
       // Login POST request
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
-      // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
+      // BorderRequest
+      val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -473,8 +473,8 @@ class OAuth2Spec extends BorderPatrolSuite {
       // Login POST request
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
-      // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
+      // BorderRequest
+      val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -526,8 +526,8 @@ class OAuth2Spec extends BorderPatrolSuite {
       // Login POST request
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
-      // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
+      // BorderRequest
+      val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -578,8 +578,8 @@ class OAuth2Spec extends BorderPatrolSuite {
       // Login POST request
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
-      // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
+      // BorderRequest
+      val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
 
       // Execute
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
@@ -616,8 +616,8 @@ class OAuth2Spec extends BorderPatrolSuite {
       // Login POST request
       val loginRequest = req("umbrella", "/signin", ("code" -> "XYZ123"))
 
-      // SessionIdRequest
-      val sessionIdRequest = SessionIdRequest(loginRequest, cust2, two, sessionId)
+      // BorderRequest
+      val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
 
       // Add certificate
       val oAuth2CodeVerify = new MockOAuth2CodeVerify()

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
@@ -5,7 +5,7 @@ import java.net.URL
 import com.lookout.borderpatrol.Binder.{BindRequest, MBinder}
 import com.lookout.borderpatrol.auth.OAuth2.OAuth2CodeVerify
 import com.lookout.borderpatrol._
-import com.lookout.borderpatrol.auth.ServiceRequest
+import com.lookout.borderpatrol.auth.CustomerIdRequest
 import com.lookout.borderpatrol.sessionx.SecretStores.InMemorySecretStore
 import com.twitter.finagle.http.Method.{Put, Get}
 import com.twitter.finagle.http.path.Path

--- a/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
@@ -170,7 +170,8 @@ object service {
           ServiceFilter(serviceMatcher) andThen /* Validate that its our service */
           SessionIdFilter(config.sessionStore) andThen /* Get or allocate Session/SignedId */
           BorderService(identityProviderChainMap(config.sessionStore),
-            accessIssuerChainMap(config.sessionStore)) /* Glue that connects to identity & access service */
+            accessIssuerChainMap(config.sessionStore),
+            serviceMatcher) /* Glue that connects to identity & access service */
     }
   }
 }

--- a/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
@@ -140,7 +140,7 @@ object service {
    */
   def identityProviderChainMap(sessionStore: SessionStore)(
     implicit store: SecretStoreApi, statsReceiver: StatsReceiver):
-  Map[String, Service[SessionIdRequest, Response]] =
+  Map[String, Service[BorderRequest, Response]] =
     Map("keymaster" -> keymasterIdentityProviderChain(sessionStore))
 
   /**
@@ -150,7 +150,7 @@ object service {
    */
   def accessIssuerChainMap(sessionStore: SessionStore)(
     implicit store: SecretStoreApi, statsReceiver: StatsReceiver):
-  Map[String, Service[SessionIdRequest, Response]] =
+  Map[String, Service[BorderRequest, Response]] =
     Map("keymaster" -> keymasterAccessIssuerChain(sessionStore))
 
   /**
@@ -163,11 +163,11 @@ object service {
     RoutingService.byPath {
       case "/logout" =>
         ExceptionFilter() andThen /* Convert exceptions to responses */
-          ServiceFilter(serviceMatcher) andThen /* Validate that its our service */
+          CustomerIdFilter(serviceMatcher) andThen /* Validate that its our service */
           LogoutService(config.sessionStore)
       case _ =>
         ExceptionFilter() andThen /* Convert exceptions to responses */
-          ServiceFilter(serviceMatcher) andThen /* Validate that its our service */
+          CustomerIdFilter(serviceMatcher) andThen /* Validate that its our service */
           SessionIdFilter(config.sessionStore) andThen /* Get or allocate Session/SignedId */
           BorderService(identityProviderChainMap(config.sessionStore),
             accessIssuerChainMap(config.sessionStore),


### PR DESCRIPTION
* Post login, BP should return 404 for unknown resources
* Pre login, BP should redirect requests (with valid or invalid paths) to login page
* And in all cases should redirect Root path to default Service

Fixes #120 