### PR TITLE
Add support for unprotected upstream services

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
@@ -71,7 +71,7 @@ object Keymaster {
         //  Preserve Response Status code by throwing AccessDenied exceptions
         case _ => {
           log.debug(s"IdentityProvider denied user: ${req.credential.uniqueId} " +
-            s"with status: ${res.status} for user")
+            s"with status: ${res.status}")
           responseFailed.incr
           Future.exception(IdentityProviderError(res.status,
             s"Invalid credentials for user ${req.credential.uniqueId}"))
@@ -232,7 +232,6 @@ object Keymaster {
    */
   def keymasterIdentityProviderChain(store: SessionStore)(
     implicit secretStoreApi: SecretStoreApi, statsReceiver: StatsReceiver): Service[BorderRequest, Response] =
-      LoginManagerFilter(LoginManagerBinder) andThen
         KeymasterTransformFilter(new OAuth2CodeVerify) andThen
         KeymasterPostLoginFilter(store) andThen
         KeymasterIdentityProvider(ManagerBinder)

--- a/bpConfig.json
+++ b/bpConfig.json
@@ -22,8 +22,7 @@
       "proto": {
         "type": "Internal",
         "loginConfirm": "/signin",
-        "path": "/a",
-        "hosts": ["http://localhost:8081"]
+        "authorizePath": "/a"
       }
     },
     {
@@ -64,6 +63,19 @@
       "path": "/top",
       "rewritePath": "/internal/top",
       "name": "two"
+    },
+    {
+      "hosts": ["http://localhost:8081"],
+      "path": "/a",
+      "protected": false,
+      "name": "checkpoint"
+    },
+    {
+      "hosts": ["http://localhost:8081"],
+      "path": "/logout",
+      "rewritePath": "/signout",
+      "protected": false,
+      "name": "logout"
     }
   ],
   "customerIdentifiers": [

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.1.7-SNAPSHOT"
+lazy val Version = "0.1.8-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
@@ -49,10 +49,6 @@ object Binder {
   /**
    * implicit values for evidence parameter of type BinderContext
    */
-  implicit object LoginManagerBinderContext extends BinderContext[LoginManager] {
-    def name(lm: LoginManager): String = lm.name
-    def hosts(lm: LoginManager): Set[URL] = lm.protoManager.hosts
-  }
   implicit object ManagerBinderContext extends BinderContext[Manager] {
     def name(m: Manager): String = m.name
     def hosts(m: Manager): Set[URL] = m.hosts
@@ -65,7 +61,6 @@ object Binder {
   /**
    * Binder objects
    */
-  case object LoginManagerBinder extends MBinder[LoginManager]
   case object ManagerBinder extends MBinder[Manager]
   case object ServiceIdentifierBinder extends MBinder[ServiceIdentifier]
 }

--- a/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
@@ -3,6 +3,7 @@ package com.lookout.borderpatrol
 import java.net.URL
 import com.twitter.finagle.http.{Method, Response, Request}
 import com.twitter.finagle.http.path.Path
+import com.twitter.logging.Logger
 import com.twitter.util.Future
 
 case class Manager(name: String, path: Path, hosts: Set[URL])
@@ -13,30 +14,24 @@ case class LoginManager(name: String, identityManager: Manager, accessManager: M
 trait ProtoManager {
   val loginConfirm: Path
   def redirectLocation(host: Option[String]): String
-  def hosts: Set[URL]
-  def isMatchingPath(p: Path): Boolean
-  def getOwnedPaths: Set[Path]
+  def isMatchingPath(p: Path): Boolean = Set(loginConfirm).filter(p.startsWith(_)).nonEmpty
 }
 
-case class InternalAuthProtoManager(loginConfirm: Path, path: Path, hsts: Set[URL])
+case class InternalAuthProtoManager(loginConfirm: Path, authorizePath: Path)
     extends ProtoManager {
-  def redirectLocation(host: Option[String]): String = path.toString
-  def hosts: Set[URL] = hsts
-  def isMatchingPath(p: Path): Boolean = Set(path, loginConfirm, Path("/logout")).filter(p.startsWith(_)).nonEmpty
-  def getOwnedPaths: Set[Path] = Set(path)
+  def redirectLocation(host: Option[String]): String = authorizePath.toString
 }
 
 case class OAuth2CodeProtoManager(loginConfirm: Path, authorizeUrl: URL, tokenUrl: URL, certificateUrl: URL,
                                   clientId: String, clientSecret: String)
     extends ProtoManager{
+  private[this] val log = Logger.get(getClass.getPackage.getName)
+
   def redirectLocation(host: Option[String]): String = {
     val hostStr = host.getOrElse(throw new Exception("Host not found in HTTP Request"))
     Request.queryString(authorizeUrl.toString, ("response_type", "code"), ("state", "foo"),
       ("client_id", clientId), ("redirect_uri", "http://" + hostStr + loginConfirm.toString))
   }
-  def hosts: Set[URL] = Set(authorizeUrl)
-  def isMatchingPath(p: Path): Boolean = Set(loginConfirm, Path("/logout")).filter(p.startsWith(_)).nonEmpty
-  def getOwnedPaths: Set[Path] = Set.empty
   def codeToToken(host: Option[String], code: String): Future[Response] = {
     val hostStr = host.getOrElse(throw new Exception("Host not found in HTTP Request"))
     val request = util.Combinators.tap(Request(Method.Post, tokenUrl.toString))(re => {
@@ -46,6 +41,7 @@ case class OAuth2CodeProtoManager(loginConfirm: Path, authorizeUrl: URL, tokenUr
         ("client_secret", clientSecret), ("resource", "00000002-0000-0000-c000-000000000000"))
         .drop(1) /* Drop '?' */
     })
+    log.debug(s"Sending: ${request} to location: ${tokenUrl}")
     BinderBase.connect(tokenUrl.toString, Set(tokenUrl), request)
   }
 }

--- a/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
@@ -6,22 +6,57 @@ import com.twitter.finagle.http.path.Path
 import com.twitter.logging.Logger
 import com.twitter.util.Future
 
+/**
+ * Manager represents upstream access and identity managers
+ * @param name name of the manager
+ * @param path path to the manager
+ * @param hosts endpoints for the manager
+ */
 case class Manager(name: String, path: Path, hosts: Set[URL])
 
+/**
+ * Login Manager defines various collections of the identity manager, access manager and proto manager.
+ * The customerIdentifier configuration picks the login manager appropriate for their cloud.
+ *
+ * @param name name of the login manager
+ * @param identityManager identity manager used by the given login manager
+ * @param accessManager access manager
+ * @param protoManager protocol used by the login manager
+ */
 case class LoginManager(name: String, identityManager: Manager, accessManager: Manager,
                         protoManager: ProtoManager)
 
+/**
+ * ProtoManager defines parameters specific to the protocol
+ */
 trait ProtoManager {
   val loginConfirm: Path
   def redirectLocation(host: Option[String]): String
   def isMatchingPath(p: Path): Boolean = Set(loginConfirm).filter(p.startsWith(_)).nonEmpty
 }
 
+/**
+ * Internal authentication, that merely redirects user to internal service that does the authentication
+ *
+ * @param loginConfirm path intercepted by bordetpatrol and internal authentication service posts
+ *                     the authentication response on this path
+ * @param authorizePath path of the internal authentication service where client is redirected
+ */
 case class InternalAuthProtoManager(loginConfirm: Path, authorizePath: Path)
     extends ProtoManager {
   def redirectLocation(host: Option[String]): String = authorizePath.toString
 }
 
+/**
+ * OAuth code framework, that redirects user to OAuth2 server.
+ *
+ * @param loginConfirm path intercepted by borderpatrol and OAuth2 server posts the oAuth2 code on this path
+ * @param authorizeUrl URL of the OAuth2 service where client is redirected for authenticaiton
+ * @param tokenUrl URL of the OAuth2 server to convert OAuth2 code to OAuth2 token
+ * @param certificateUrl URL of the OAuth2 server to fetch the certificate for verifying token signature
+ * @param clientId Id used for communicating with OAuth2 server
+ * @param clientSecret Secret used for communicating with OAuth2 server
+ */
 case class OAuth2CodeProtoManager(loginConfirm: Path, authorizeUrl: URL, tokenUrl: URL, certificateUrl: URL,
                                   clientId: String, clientSecret: String)
     extends ProtoManager{

--- a/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
@@ -14,7 +14,8 @@ import com.twitter.finagle.http.path.Path
  * @param rewritePath The (optional) internal url path prefix to the internal service. If present,
  *                    it replaces the external path in the Request URI
  */
-case class ServiceIdentifier(name: String, hosts: Set[URL], path: Path, rewritePath: Option[Path]) {
+case class ServiceIdentifier(name: String, hosts: Set[URL], path: Path, rewritePath: Option[Path],
+                             protekted: Boolean) {
   def isServicePath(p: Path): Boolean =
     p.startsWith(path)
 }

--- a/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
@@ -13,6 +13,7 @@ import com.twitter.finagle.http.path.Path
  * @param path The external url path prefix that routes to the internal service
  * @param rewritePath The (optional) internal url path prefix to the internal service. If present,
  *                    it replaces the external path in the Request URI
+ * @param protekted The service is protected or unprotected (i.e. does not go through access issuer)
  */
 case class ServiceIdentifier(name: String, hosts: Set[URL], path: Path, rewritePath: Option[Path],
                              protekted: Boolean) {

--- a/core/src/main/scala/com/lookout/borderpatrol/ServiceMatcher.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/ServiceMatcher.scala
@@ -1,7 +1,7 @@
 package com.lookout.borderpatrol
 
 import com.twitter.finagle.http.Request
-import com.twitter.finagle.http.path.Path
+import com.twitter.finagle.http.path.{Root, Path}
 
 /*
  * We derive a service `name` (a [[String]] name referencing a [[com.twitter.finagle.Name Name]]) via the `Path`
@@ -86,7 +86,8 @@ case class ServiceMatcher(customerIds: Set[CustomerIdentifier], serviceIds: Set[
   def get(req: Request): Option[(CustomerIdentifier, ServiceIdentifier)] =
     (req.host.flatMap(subdomain), path(Path(req.path))) match {
       case (Some(cid), Some(sid)) => Some((cid, sid))
-      case (Some(cid), None) if (cid.isLoginManagerPath(Path(req.path))) => Some((cid, cid.defaultServiceId))
+      case (Some(cid), None) if cid.isLoginManagerPath(Path(req.path)) => Some((cid, cid.defaultServiceId))
+      case (Some(cid), None) if Root.startsWith(Path(req.path)) => Some((cid, cid.defaultServiceId))
       case _ => None
     }
 }

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
@@ -38,14 +38,14 @@ object AccessIdRequest {
  * Determines the service that the request is trying to contact
  * If the service doesn't exist, it returns a 404 Not Found response
  *
- * @param matchers
+ * @param matcher
  */
-case class CustomerIdFilter(matchers: ServiceMatcher)
+case class CustomerIdFilter(matcher: ServiceMatcher)
     extends Filter[Request, Response, CustomerIdRequest, Response] {
   private[this] val log = Logger.get(getClass.getPackage.getName)
 
   def apply(req: Request, service: Service[CustomerIdRequest, Response]): Future[Response] = {
-    req.host.flatMap(matchers.subdomain) match {
+    req.host.flatMap(matcher.subdomain) match {
       case Some(cid) => {
         log.debug(s"Processing: Request(${req.method} " +
           s"${req.host.fold("null-hostname")(h => s"${h}${req.path}")}) " +
@@ -92,7 +92,11 @@ case class SessionIdFilter(store: SessionStore)(implicit secretStore: SecretStor
 }
 
 /**
- * This is a border service that glues the main chain with identityProvider or accessIssuer chains
+ * This is a border service that glues the main chain with
+ * - unprotected upstream service chain
+ * - identityProvider chain or
+ * - accessIssuer chain
+ *
  * E.g.
  * - If SignedId is authenticated
  *   - if path is NOT a service path, then return Status NotFound
@@ -106,9 +110,14 @@ case class SessionIdFilter(store: SessionStore)(implicit secretStore: SecretStor
  */
 case class BorderService(identityProviderMap: Map[String, Service[BorderRequest, Response]],
                          accessIssuerMap: Map[String, Service[BorderRequest, Response]],
-                         matchers: ServiceMatcher)
+                         matcher: ServiceMatcher,
+                         serviceBinder: MBinder[ServiceIdentifier])(implicit statsReceiver: StatsReceiver)
     extends Service[SessionIdRequest, Response] {
   private[this] val log = Logger.get(getClass.getPackage.getName)
+  private[this] val requestSends = statsReceiver.counter("unprotected.upstream.service.request.sends")
+  private[this] val unprotectedServiceChain = RewriteFilter() andThen Service.mk[BorderRequest, Response] {
+    br => serviceBinder(BindRequest(br.serviceId, br.req)) }
+
 
   def sendToIdentityProvider(req: BorderRequest): Future[Response] = {
     log.debug(s"Send: ${req.req} for Session: ${req.sessionId.toLogIdString} " +
@@ -130,6 +139,14 @@ case class BorderService(identityProviderMap: Map[String, Service[BorderRequest,
     }
   }
 
+  def sendToUnprotectedService(req: BorderRequest): Future[Response] = {
+    requestSends.incr
+    log.debug(s"Send: ${req.req} for Session: ${req.sessionId.toLogIdString} " +
+      s"to the unprotected upstream service: ${req.serviceId.name}")
+    /* Route through a Rewrite filter */
+    unprotectedServiceChain(req)
+  }
+
   def redirectTo(location: String): Response =
     tap(Response(Status.Found))(res => res.location = location)
 
@@ -139,7 +156,6 @@ case class BorderService(identityProviderMap: Map[String, Service[BorderRequest,
     redirectTo(req.serviceId.path.toString).toFuture
   }
 
-
   def redirectToLogin(req: SessionIdRequest): Future[Response] = {
     val path = req.customerId.loginManager.protoManager.redirectLocation(req.req.host)
     log.debug(s"Redirecting the ${req.req} for Untagged Session: ${req.sessionId.toLogIdString} " +
@@ -147,18 +163,33 @@ case class BorderService(identityProviderMap: Map[String, Service[BorderRequest,
     redirectTo(path).toFuture
   }
 
+  /**
+   * Matching order:
+   * 1. Untagged/Authenticated, ServiceIdentifier NOT found, but path matches Root i.e. "/"
+   * 2. Untagged, ServiceIdentifier found/Not, but path matches LoginManager confirm path
+   * 3. Untagged/Authenticated, Unprotected ServiceIdentifier found
+   * 4. Authenticated, protected ServiceIdentifier found
+   * 5. Authenticated, ServiceIdentifier NOT found
+   * 6. Untagged
+   *
+   * @param req
+   * @return
+   */
   def apply(req: SessionIdRequest): Future[Response] =
-    (req.sessionId.tag, matchers.path(Path(req.req.path))) match {
-      /* If no path provided, then redirect to default service */
+    (req.sessionId.tag, matcher.path(Path(req.req.path))) match {
+      /* 1. redirect to default service */
       case (_, None) if Root.startsWith(Path(req.req.path)) =>
         redirectToService(BorderRequest(req, req.customerId.defaultServiceId))
-      case (AuthenticatedTag, Some(serviceId)) => sendToAccessIssuer(BorderRequest(req, serviceId))
-      /* If path doesn't match the services, then return a NotFound */
-      case (AuthenticatedTag, None) => Response(Status.NotFound).toFuture
-      /* If path matches Login Manager, then send it to Identity Provider */
-      case (Untagged, None) if req.customerId.isLoginManagerPath(Path(req.req.path))  =>
+      /* 2. dispatch to Identity Provider chain */
+      case (Untagged, _) if req.customerId.isLoginManagerPath(Path(req.req.path)) =>
         sendToIdentityProvider(BorderRequest(req, req.customerId.defaultServiceId))
-      /* For untagged sessions, redirect it to Login */
+      /* 3. dispatch to unprotected service */
+      case (_, Some(serviceId)) if !serviceId.protekted => sendToUnprotectedService(BorderRequest(req, serviceId))
+      /* 4. dispatch to protected service via accessIssuer chain */
+      case (AuthenticatedTag, Some(serviceId)) => sendToAccessIssuer(BorderRequest(req, serviceId))
+      /* 5. return a NotFound */
+      case (AuthenticatedTag, None) => Response(Status.NotFound).toFuture
+      /* 6. redirect it to Login */
       case (Untagged, _) => redirectToLogin(req)
     }
 }
@@ -210,7 +241,7 @@ case class IdentityFilter[A : SessionDataEncoder](store: SessionStore)(implicit 
     }
 
   def apply(req: BorderRequest, service: Service[AccessIdRequest[A], Response]): Future[Response] =
-    identity(req.sessionId).flatMap(i => i match {
+    identity(req.sessionId).flatMap {
       case id: Id[A] => service(AccessIdRequest(req, id))
       case EmptyIdentity => for {
         s <- Session(req.req)
@@ -221,31 +252,6 @@ case class IdentityFilter[A : SessionDataEncoder](store: SessionStore)(implicit 
           log.info(s"Failed to find Session: ${req.sessionId.toLogIdString} for Request: ${req.req}, " +
             s"allocating a new session: ${s.id.toLogIdString}, redirecting to location: ${res.location}")
         }
-    })
-}
-
-/**
- * Decodes the methods Get and Post differently
- * - Get is directed to login form
- * - Post processes the login credentials
- *
- * @param binder It binds to upstream login provider using the information passed in LoginManager
- */
-case class LoginManagerFilter(binder: MBinder[LoginManager])(implicit statsReceiver: StatsReceiver)
-    extends Filter[BorderRequest, Response, BorderRequest, Response] {
-  private[this] val log = Logger.get(getClass.getPackage.getName)
-  private[this] val requestSends = statsReceiver.counter("login.manager.request.sends")
-
-  def apply(req: BorderRequest,
-            service: Service[BorderRequest, Response]): Future[Response] =
-    Path(req.req.path) match {
-      case req.customerId.loginManager.protoManager.loginConfirm => service(req)
-      case _ => {
-        requestSends.incr
-        log.debug(s"Send: ${req.req} for Session: ${req.sessionId.toLogIdString} " +
-          s"to the Login Manager: ${req.customerId.loginManager.name}")
-        binder(BindRequest(req.customerId.loginManager, req.req))
-      }
     }
 }
 
@@ -266,7 +272,7 @@ case class AccessFilter[A, B](binder: MBinder[ServiceIdentifier])(implicit stats
         tap(req.req) { r => {
           requestSends.incr
           log.debug(s"Send: ${req.req} for Session: ${req.sessionId.toLogIdString} " +
-            s"to the upstream service: ${req.serviceId.name}")
+            s"to the protected upstream service: ${req.serviceId.name}")
           r.headerMap.add("Auth-Token", accessResp.access.access.toString)
         }})
       )

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
@@ -235,7 +235,8 @@ case class IdentityFilter[A : SessionDataEncoder](store: SessionStore)(implicit 
       sessionMaybe <- store.get[A](sessionId)
     } yield sessionMaybe.fold[Identity[A]](EmptyIdentity)(s => Id(s.data))) handle {
       case e => {
-        log.warning(s"Failed to retrieve Identity for Session: ${sessionId}, from sessionStore with: ${e.getMessage}")
+        log.warning(s"Failed to retrieve Identity for Session: ${sessionId.toLogIdString}, " +
+          s"from sessionStore with: ${e.getMessage}")
         EmptyIdentity
       }
     }

--- a/core/src/test/scala/com/lookout/borderpatrol/test/BinderSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/BinderSpec.scala
@@ -1,68 +1,34 @@
 package com.lookout.borderpatrol.test
 
-import java.net.URL
-
 import com.lookout.borderpatrol._
 import com.lookout.borderpatrol.Binder._
-import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Status, Response, Request}
-import com.twitter.finagle.http.path.Path
-import com.twitter.util.{Await, Future}
+import com.twitter.util.Await
+
 
 class BinderSpec extends BorderPatrolSuite {
-  val urls = Set(new URL("http://localhost:5679"))
+  import sessionx.helpers._
 
   override def afterEach(): Unit = {
-    BinderBase.clear
-  }
-
-  //  Managers
-  val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), urls)
-  val keymasterAccessManager = Manager("keymaster", Path("/accessIssuer"), urls)
-  val internalProtoManager = InternalAuthProtoManager(Path("/loginConfirm"), Path("/check"), urls)
-  val checkpointLoginManager = LoginManager("checkpoint", keymasterIdManager, keymasterAccessManager,
-    internalProtoManager)
-
-  // sids
-  val one = ServiceIdentifier("one", urls, Path("/ent"), None)
-  val cust = CustomerIdentifier("enterprise", one, checkpointLoginManager)
-
-  // Request helper
-  def req(path: String): Request =
-    Request(s"http://localhost${path.toString}")
-
-  def mkTestService[A](f: (A) => Future[Response]) : Service[A, Response] = new Service[A, Response] {
-    def apply(request: A) = f(request)
+    try {
+      super.afterEach() // To be stackable, must call super.afterEach
+    }
+    finally {
+      BinderBase.clear
+    }
   }
 
   behavior of "ManagerBinder"
 
   it should "successfully connect to server and returns the response" in {
     val server = com.twitter.finagle.Http.serve(
-      "localhost:5679", mkTestService[Request]{_ => Response(Status.NotAcceptable).toFuture })
+      "localhost:5678", mkTestService[Request, Response]{_ => Response(Status.Found).toFuture })
     try {
-      val bindReq = BindRequest[Manager](keymasterIdManager, req(keymasterIdManager.path.toString))
-      val output = ManagerBinder(bindReq)
-      Await.result(output).status should be(Status.NotAcceptable)
+      val bindReq = BindRequest[Manager](keymasterIdManager, Request(keymasterIdManager.path.toString))
+      val output = ManagerBinder.apply(bindReq)
+      Await.result(output).status should be(Status.Found)
       /* Make sure client is cached in the cache */
       BinderBase.get(keymasterIdManager.name) should not be None
-    } finally {
-      server.close()
-    }
-  }
-
-  behavior of "LoginManagerBinder"
-
-  it should "successfully connect to server and returns the response" in {
-    val server = com.twitter.finagle.Http.serve(
-      "localhost:5679", mkTestService[Request]{_ => Response(Status.NotAcceptable).toFuture })
-    try {
-      val bindReq = BindRequest[LoginManager](checkpointLoginManager,
-        req(checkpointLoginManager.protoManager.redirectLocation(None)))
-      val output = LoginManagerBinder(bindReq)
-      Await.result(output).status should be(Status.NotAcceptable)
-      /* Make sure client is cached in the cache */
-      BinderBase.get(checkpointLoginManager.name) should not be None
     } finally {
       server.close()
     }
@@ -72,9 +38,9 @@ class BinderSpec extends BorderPatrolSuite {
 
   it should "successfully connect to server and returns the response" in {
     val server = com.twitter.finagle.Http.serve(
-      "localhost:5679", mkTestService[Request]{_ => Response(Status.NotAcceptable).toFuture })
+      "localhost:5678", mkTestService[Request, Response]{_ => Response(Status.NotAcceptable).toFuture })
     try {
-      val bindReq = BindRequest[ServiceIdentifier](one, req(one.path.toString))
+      val bindReq = BindRequest[ServiceIdentifier](one, Request(one.path.toString))
       val output = ServiceIdentifierBinder(bindReq)
       Await.result(output).status should be(Status.NotAcceptable)
       /* Make sure client is cached in the cache */

--- a/core/src/test/scala/com/lookout/borderpatrol/test/ServiceMatcherSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/ServiceMatcherSpec.scala
@@ -6,11 +6,11 @@ import com.twitter.finagle.http.path.Path
 class ServiceMatcherSpec extends BorderPatrolSuite {
   import sessionx.helpers._
 
-  val sOneOne = ServiceIdentifier("eOne", urls, Path("/ent1"), None)
-  val sOneTwo = ServiceIdentifier("eTwo", urls, Path("/ent2"), None)
-  val sTwo = ServiceIdentifier("two", urls, Path("/api"), None)
-  val sThree = ServiceIdentifier("three", urls, Path("/apis"), None)
-  val sFour = ServiceIdentifier("four", urls, Path("/apis/test"), None)
+  val sOneOne = ServiceIdentifier("eOne", urls, Path("/ent1"), None, true)
+  val sOneTwo = ServiceIdentifier("eTwo", urls, Path("/ent2"), None, true)
+  val sTwo = ServiceIdentifier("two", urls, Path("/api"), None, true)
+  val sThree = ServiceIdentifier("three", urls, Path("/apis"), None, true)
+  val sFour = ServiceIdentifier("four", urls, Path("/apis/test"), None, true)
   val serviceIds = Set(sOneOne, sOneTwo, sTwo, sThree, sFour)
   val cOne = CustomerIdentifier("enterprise", sOneOne, checkpointLoginManager)
   val cTwo = CustomerIdentifier("api", two, umbrellaLoginManager)
@@ -46,9 +46,9 @@ class ServiceMatcherSpec extends BorderPatrolSuite {
   }
 
   it should "match the longest get" in {
-    testServiceMatcher.get(req("enterprise", "/")) should be(None)
+    testServiceMatcher.get(req("enterprise", "/")).value should be((cOne, sOneOne))
     testServiceMatcher.get(req("enterprise", "/ent2")).value should be((cOne, sOneTwo))
-    testServiceMatcher.get(req("enterprise", "/check")).value should be((cOne, sOneOne))
+    testServiceMatcher.get(req("enterprise", "/check")) should be(None)
     testServiceMatcher.get(req("enterprise", "/loginConfirm")).value should be((cOne, sOneOne))
     testServiceMatcher.get(req("api", "/check")) should be(None)
     testServiceMatcher.get(req("api", "/loginConfirm")) should be(None)

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
@@ -26,7 +26,12 @@ class OAuth2Spec extends BorderPatrolSuite {
   import OAuth2._
 
   override def afterEach(): Unit = {
-    BinderBase.clear
+    try {
+      super.afterEach() // To be stackable, must call super.afterEach
+    }
+    finally {
+      BinderBase.clear
+    }
   }
 
   // Mock

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SecretStoresSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SecretStoresSpec.scala
@@ -19,7 +19,12 @@ class SecretStoresSpec extends BorderPatrolSuite {
   import sessionx.helpers.{secretStore => store, _}, secrets._
 
   override def afterEach(): Unit = {
-    BinderBase.clear
+    try {
+      super.afterEach() // To be stackable, must call super.afterEach
+    }
+    finally {
+      BinderBase.clear
+    }
   }
 
   //val secretsJsonString = SecretsEncoder.EncodeJson.encode(testSecrets).nospaces
@@ -117,6 +122,7 @@ class SecretStoresSpec extends BorderPatrolSuite {
       consulSecretStore.current should be (testSecrets.current)
       consulSecretStore.previous should be (testSecrets.previous)
       consulSecretStore.current should not be (testExpiredSecrets.current)
+      consulSecretStore.timer.stop()
 
     } finally {
       server.close()
@@ -160,6 +166,7 @@ class SecretStoresSpec extends BorderPatrolSuite {
 
       /* Validate (previous of new Secrets matches with current of old Secrets) */
       consulSecretStore.previous should be (testExpiredSecrets.current)
+      consulSecretStore.timer.stop()
 
     } finally {
       server.close()
@@ -200,6 +207,7 @@ class SecretStoresSpec extends BorderPatrolSuite {
 
       /* Validate (previous of new Secrets matches with current of old Secrets) */
       consulSecretStore.previous should be (testSecrets.current)
+      consulSecretStore.timer.stop()
 
     } finally {
       server.close()
@@ -244,6 +252,7 @@ class SecretStoresSpec extends BorderPatrolSuite {
       /* Validate */
       consulSecretStore.current should be (testSecrets.current)
       consulSecretStore.previous should be (testSecrets.previous)
+      consulSecretStore.timer.stop()
 
     } finally {
       server.close()
@@ -287,6 +296,7 @@ class SecretStoresSpec extends BorderPatrolSuite {
       /* Validate (exception thrown by Step-1 GET parsing is caught internally, _secrets remains unchanged) */
       consulSecretStore.current should be (testSecrets.current)
       consulSecretStore.previous should be (testSecrets.previous)
+      consulSecretStore.timer.stop()
 
     } finally {
       server.close()
@@ -330,6 +340,7 @@ class SecretStoresSpec extends BorderPatrolSuite {
        */
       consulSecretStore.current should be (testSecrets.current)
       consulSecretStore.previous should be (testSecrets.previous)
+      consulSecretStore.timer.stop()
 
     } finally {
       server.close()
@@ -368,6 +379,7 @@ class SecretStoresSpec extends BorderPatrolSuite {
       /* Validate (exception thrown is caught internally, _secrets remains unchanged) */
       consulSecretStore.current should be (testSecrets.current)
       consulSecretStore.previous should be (testSecrets.previous)
+      consulSecretStore.timer.stop()
 
     } finally {
       server.close()
@@ -412,6 +424,7 @@ class SecretStoresSpec extends BorderPatrolSuite {
       /* Validate (failure is handled internally, Secrets remain unchanged due to failure) */
       consulSecretStore.current should be (testSecrets.current)
       consulSecretStore.previous should be (testSecrets.previous)
+      consulSecretStore.timer.stop()
 
     } finally {
       server.close()
@@ -458,6 +471,7 @@ class SecretStoresSpec extends BorderPatrolSuite {
       /* Validate (exception thrown is caught internally, _secrets remains unchanged) */
       consulSecretStore.current should be (testSecrets.current)
       consulSecretStore.previous should be (testSecrets.previous)
+      consulSecretStore.timer.stop()
 
     } finally {
       server.close()

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
@@ -5,15 +5,12 @@ import java.net.URL
 import com.lookout.borderpatrol.Binder.{BindRequest, MBinder}
 import com.lookout.borderpatrol.auth.OAuth2.OAuth2CodeVerify
 import com.lookout.borderpatrol._
-import com.lookout.borderpatrol.auth.CustomerIdRequest
 import com.lookout.borderpatrol.sessionx.SecretStores.InMemorySecretStore
-import com.twitter.finagle.http.Method.{Put, Get}
 import com.twitter.finagle.http.path.Path
-import com.twitter.finagle.http.{RequestBuilder, Status, Response, Request}
+import com.twitter.finagle.http.{RequestBuilder, Response, Request}
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.util._
-import com.twitter.finagle.{Service, http}
-import scala.util.{Success, Try}
+import com.twitter.finagle.Service
 import com.twitter.bijection.Injection
 import com.twitter.util.{Await, Time}
 
@@ -21,17 +18,17 @@ import com.twitter.util.{Await, Time}
 object helpers {
   import com.lookout.borderpatrol.sessionx._
   import com.lookout.borderpatrol.crypto.Generator.{EntropyGenerator => Entropy}
-   /**
-    * Common usage of secrets across tests
-    */
-   object secrets {
-     val current = Secret(Injection.short2BigEndian(1), Secret.currentExpiry, Entropy(16))
-     val previous = Secret(Injection.short2BigEndian(2), Time.fromMilliseconds(0), Entropy(16))
-     val invalid = Secret(Injection.short2BigEndian(3), Time.now, Entropy(16)) // not in store
-     val testSecrets = Secrets(current, previous)
-     val testExpiredSecrets = Secrets(invalid, previous)
-   }
-   implicit val secretStore = InMemorySecretStore(secrets.testSecrets)
+  /**
+   * Common usage of secrets across tests
+   */
+  object secrets {
+    val current = Secret(Injection.short2BigEndian(1), Secret.currentExpiry, Entropy(16))
+    val previous = Secret(Injection.short2BigEndian(2), Time.fromMilliseconds(0), Entropy(16))
+    val invalid = Secret(Injection.short2BigEndian(3), Time.now, Entropy(16)) // not in store
+    val testSecrets = Secrets(current, previous)
+    val testExpiredSecrets = Secrets(invalid, previous)
+  }
+  implicit val secretStore = InMemorySecretStore(secrets.testSecrets)
 
   /**
    * Test stats receiver
@@ -63,7 +60,7 @@ object helpers {
   //  Managers
   val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), urls)
   val keymasterAccessManager = Manager("keymaster", Path("/accessIssuer"), urls)
-  val internalProtoManager = InternalAuthProtoManager(Path("/loginConfirm"), Path("/check"), urls)
+  val internalProtoManager = InternalAuthProtoManager(Path("/loginConfirm"), Path("/check"))
   val checkpointLoginManager = LoginManager("checkpoint", keymasterIdManager, keymasterAccessManager,
     internalProtoManager)
   val oauth2CodeProtoManager = OAuth2CodeProtoManager(Path("/signin"),
@@ -86,15 +83,16 @@ object helpers {
   val oAuth2CodeVerify = new OAuth2CodeVerify
 
   // sids
-  val one = ServiceIdentifier("one", urls, Path("/ent"), None)
-  val oneTwo = ServiceIdentifier("oneTwo", urls, Path("/ent2"), None)
+  val one = ServiceIdentifier("one", urls, Path("/ent"), None, true)
+  val oneTwo = ServiceIdentifier("oneTwo", urls, Path("/ent2"), None, true)
   val cust1 = CustomerIdentifier("enterprise", one, checkpointLoginManager)
-  val two = ServiceIdentifier("two", urls, Path("/umb"), Some(Path("/broken/umb")))
+  val two = ServiceIdentifier("two", urls, Path("/umb"), Some(Path("/broken/umb")), true)
   val cust2 = CustomerIdentifier("sky", two, umbrellaLoginManager)
-  val three = ServiceIdentifier("three", urls, Path("/rain"), None)
+  val three = ServiceIdentifier("three", urls, Path("/rain"), None, true)
   val cust3 = CustomerIdentifier("rainy", three, rainyLoginManager)
+  val checkpointSid = ServiceIdentifier("checkpoint", urls, Path("/check"), None, false)
   val cids = Set(cust1, cust2, cust3)
-  val sids = Set(one, oneTwo, two, three)
+  val sids = Set(one, oneTwo, two, three, checkpointSid)
   val serviceMatcher = ServiceMatcher(cids, sids)
   val sessionStore = SessionStores.InMemoryStore
 
@@ -112,11 +110,6 @@ object helpers {
   def mkTestManagerBinder(f: (BindRequest[Manager]) => Future[Response]): TestManagerBinder = new TestManagerBinder {
     override def apply(request: BindRequest[Manager]) = f(request)
   }
-  case class TestLoginManagerBinder() extends MBinder[LoginManager]
-  def mkTestLoginManagerBinder(f: (BindRequest[LoginManager]) => Future[Response]): TestLoginManagerBinder =
-    new TestLoginManagerBinder {
-      override def apply(request: BindRequest[LoginManager]) = f(request)
-    }
   case class TestServiceIdentifierBinder() extends MBinder[ServiceIdentifier]
   def mkTestSidBinder(f: (BindRequest[ServiceIdentifier]) => Future[Response]): TestServiceIdentifierBinder =
     new TestServiceIdentifierBinder {

--- a/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
@@ -15,7 +15,7 @@ object BorderPatrolApp extends TwitterServer with Config {
     implicit val bpStatsReceiver = statsReceiver
 
     // Create a StatsD exporter
-    val statsdReporter = new StatsdExporter(serverConfig.statsdExporterConfig)
+    val statsdReporter = StatsdExporter(serverConfig.statsdExporterConfig)
 
     // Create a server
     val server1 = Http.serve(":8080", MainServiceChain)

--- a/server/src/test/scala/com/lookout/borderpatrol/server/StatsdExporterSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/StatsdExporterSpec.scala
@@ -4,8 +4,9 @@ import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.channels.DatagramChannel
 
+import com.lookout.borderpatrol.BinderBase
 import com.lookout.borderpatrol.test.BorderPatrolSuite
-import com.twitter.finagle.util.DefaultTimer
+import com.twitter.finagle.util.{HashedWheelTimer, DefaultTimer}
 import com.twitter.io.Buf
 import com.twitter.common.metrics.{AbstractGauge, Metrics}
 import com.twitter.util.Duration
@@ -19,9 +20,9 @@ class StatsdExporterSpec extends BorderPatrolSuite {
   private[this] val host = s"localhost:$port"
 
   // StatdExporter
-  val defaultStatsdExporterConfig = StatsdExporterConfig("localhost:1234", 300, "prefix")
+  val defaultStatsdExporterConfig = StatsdExporterConfig(host, 300, "prefix")
 
-  private[this] def receiveString: Option[String] = {
+  private[this] def receiveStat: Option[String] = {
     val buf1 = ByteBuffer.allocateDirect(128)
     server.receive(buf1)
     buf1.flip()
@@ -29,26 +30,35 @@ class StatsdExporterSpec extends BorderPatrolSuite {
     return Buf.Utf8.unapply(buf2)
   }
 
+  private[this] def receiveStats: IndexedSeq[String] = {
+    for {
+      i <- 1 to 50
+      rbuf <- receiveStat
+    }  yield rbuf
+  }
+
   behavior of "StatsdExporter"
 
   it should "instantiate with StatsExporterConfig" in {
-    val metrics = new StatsdExporter(defaultStatsdExporterConfig)
-    metrics.report()
+    val exporter = StatsdExporter(defaultStatsdExporterConfig)
+    exporter.report()
+    exporter.timer.stop()
   }
 
   it should "report counter increment" in {
     val metrics1 = Metrics.createDetached()
-    val exporter1 = new StatsdExporter(metrics1, DefaultTimer.twitter,
+    val exporter1 = StatsdExporter(metrics1, HashedWheelTimer(),
       "ut", Duration.fromSeconds(300), host)
     val c = metrics1.createCounter("counter1")
     c.increment()
     exporter1.report()
-    receiveString should be (Some("ut.counter1:1|c"))
+    receiveStats.contains("ut.counter1:1|c") should be (true)
+    exporter1.timer.stop()
   }
 
   it should "report gauge increment" in {
     val metrics2 = Metrics.createDetached()
-    val exporter2 = new StatsdExporter(metrics2, DefaultTimer.twitter,
+    val exporter2 = StatsdExporter(metrics2, HashedWheelTimer(),
       "ut", Duration.fromSeconds(300), host)
     var x = 0
     val g = new AbstractGauge[Number]("gauge1") {
@@ -57,26 +67,29 @@ class StatsdExporterSpec extends BorderPatrolSuite {
     val gauge = metrics2.registerGauge(g)
     x = 10
     exporter2.report()
-    receiveString should be (Some("ut.gauge1:10|g"))
+    receiveStats.contains("ut.gauge1:10|g") should be (true)
+    exporter2.timer.stop()
   }
 
   it should "report historgram increment" in {
     val metrics3 = Metrics.createDetached()
-    val exporter3 = new StatsdExporter(metrics3, DefaultTimer.twitter,
+    val exporter3 = StatsdExporter(metrics3, HashedWheelTimer(),
       "ut", Duration.fromSeconds(300), host)
     val r = new scala.util.Random(10000)
     val histo = metrics3.createHistogram("histo")
     exporter3.report()
-    receiveString should be (Some("ut.histo.count:0|g"))
-    receiveString should be (Some("ut.histo.avg:0.00|t"))
-    receiveString should be (Some("ut.histo.min:0|t"))
-    receiveString should be (Some("ut.histo.max:0|t"))
-    receiveString should be (Some("ut.histo.stddev:0.00|t"))
-    receiveString should be (Some("ut.histo.p50:0|t"))
-    receiveString should be (Some("ut.histo.p90:0|t"))
-    receiveString should be (Some("ut.histo.p95:0|t"))
-    receiveString should be (Some("ut.histo.p99:0|t"))
-    receiveString should be (Some("ut.histo.p999:0|t"))
-    receiveString should be (Some("ut.histo.p9999:0|t"))
+    val stats = receiveStats
+    stats.contains("ut.histo.count:0|g") should be (true)
+    stats.contains("ut.histo.avg:0.00|t") should be (true)
+    stats.contains("ut.histo.min:0|t") should be (true)
+    stats.contains("ut.histo.max:0|t") should be (true)
+    stats.contains("ut.histo.stddev:0.00|t") should be (true)
+    stats.contains("ut.histo.p50:0|t") should be (true)
+    stats.contains("ut.histo.p90:0|t") should be (true)
+    stats.contains("ut.histo.p95:0|t") should be (true)
+    stats.contains("ut.histo.p99:0|t") should be (true)
+    stats.contains("ut.histo.p999:0|t") should be (true)
+    stats.contains("ut.histo.p9999:0|t") should be (true)
+    exporter3.timer.stop()
   }
 }


### PR DESCRIPTION
- Checkpoint, ErrorRedirect, logout all become unprotected upstream services
- Remove LoginManagerBinder (it doesn’t connect to upstream anymore)
- Remove LoginManagerFilter (replaced by unprotectedServiceChain inside BorderService)
- Moved alternate constructor for StatsdExporter to object (so that we can avoid the new)

Also:
- Fixed afterEach to call super
- Fixed ConsulSecretStore to use HashWheeledTimer instead of DefaultTimer.twitter (deprecated)
- Fixed SecretStoreSpec to close the timer
- Cleaned up BinderSpec

Fixes #123