### PR TITLE
Add config for port, external endpoint, loggedOut url

### DIFF
--- a/bpConfig.json
+++ b/bpConfig.json
@@ -1,4 +1,6 @@
 {
+  "port": "8080",
+  "externalEndpoint": "http://localhost:8080",
   "statsdReporter": {
      "host": "localhost:8125",
      "durationInSec": 60,
@@ -35,6 +37,7 @@
         "authorizeUrl": "https://login.zoo.com:443/common/oauth2/authorize",
         "tokenUrl": "https://login.zoo.com:443/common/oauth2/token",
         "certificateUrl": "https://login.zoo.com:443/common/certificate",
+        "loggedOutUrl": "http://www.zoo.com",
         "clientId": "MySecretClientId",
         "clientSecret": "MySecretClientSecret"
       }

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.1.8-SNAPSHOT"
+lazy val Version = "0.1.9-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
@@ -31,7 +31,8 @@ case class LoginManager(name: String, identityManager: Manager, accessManager: M
  */
 trait ProtoManager {
   val loginConfirm: Path
-  def redirectLocation(host: Option[String]): String
+  val loggedOutUrl: Option[URL]
+  def redirectLocation: String
   def isMatchingPath(p: Path): Boolean = Set(loginConfirm).filter(p.startsWith(_)).nonEmpty
 }
 
@@ -41,38 +42,42 @@ trait ProtoManager {
  * @param loginConfirm path intercepted by bordetpatrol and internal authentication service posts
  *                     the authentication response on this path
  * @param authorizePath path of the internal authentication service where client is redirected
+ * @param loggedOutUrl A url where user is redirected after the Logout
  */
-case class InternalAuthProtoManager(loginConfirm: Path, authorizePath: Path)
+case class InternalAuthProtoManager(loginConfirm: Path, authorizePath: Path, loggedOutUrl: Option[URL])
     extends ProtoManager {
-  def redirectLocation(host: Option[String]): String = authorizePath.toString
+  def redirectLocation: String = authorizePath.toString
 }
 
 /**
  * OAuth code framework, that redirects user to OAuth2 server.
  *
+ * @param bpExternalEndpoint Externally visible BorderPatrol URL
  * @param loginConfirm path intercepted by borderpatrol and OAuth2 server posts the oAuth2 code on this path
  * @param authorizeUrl URL of the OAuth2 service where client is redirected for authenticaiton
  * @param tokenUrl URL of the OAuth2 server to convert OAuth2 code to OAuth2 token
  * @param certificateUrl URL of the OAuth2 server to fetch the certificate for verifying token signature
+ * @param loggedOutUrl A Url where user is redirected after the Logout
  * @param clientId Id used for communicating with OAuth2 server
  * @param clientSecret Secret used for communicating with OAuth2 server
  */
-case class OAuth2CodeProtoManager(loginConfirm: Path, authorizeUrl: URL, tokenUrl: URL, certificateUrl: URL,
-                                  clientId: String, clientSecret: String)
+case class OAuth2CodeProtoManager(bpExternalEndpoint: URL, loginConfirm: Path, authorizeUrl: URL, tokenUrl: URL,
+                                  certificateUrl: URL, loggedOutUrl: Option[URL], clientId: String,
+                                  clientSecret: String)
     extends ProtoManager{
   private[this] val log = Logger.get(getClass.getPackage.getName)
 
-  def redirectLocation(host: Option[String]): String = {
-    val hostStr = host.getOrElse(throw new Exception("Host not found in HTTP Request"))
+  def redirectLocation: String =
     Request.queryString(authorizeUrl.toString, ("response_type", "code"), ("state", "foo"),
-      ("client_id", clientId), ("redirect_uri", "http://" + hostStr + loginConfirm.toString))
-  }
-  def codeToToken(host: Option[String], code: String): Future[Response] = {
-    val hostStr = host.getOrElse(throw new Exception("Host not found in HTTP Request"))
+      ("client_id", clientId),
+      ("redirect_uri", s"$bpExternalEndpoint$loginConfirm"))
+
+  def codeToToken(code: String): Future[Response] = {
     val request = util.Combinators.tap(Request(Method.Post, tokenUrl.toString))(re => {
       re.contentType = "application/x-www-form-urlencoded"
       re.contentString = Request.queryString(("grant_type", "authorization_code"), ("client_id", clientId),
-        ("code", code), ("redirect_uri", "http://" + hostStr + loginConfirm.toString),
+        ("code", code),
+        ("redirect_uri", s"$bpExternalEndpoint$loginConfirm"),
         ("client_secret", clientSecret), ("resource", "00000002-0000-0000-c000-000000000000"))
         .drop(1) /* Drop '?' */
     })

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/OAuth2.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/OAuth2.scala
@@ -151,8 +151,7 @@ object OAuth2 {
      */
     def codeToClaimsSet(req: BorderRequest, protoManager: OAuth2CodeProtoManager): Future[JWTClaimsSet] = {
       for {
-        aadToken <- protoManager.codeToToken(
-          req.req.host, req.req.getParam("code")).flatMap(res => res.status match {
+        aadToken <- protoManager.codeToToken(req.req.getParam("code")).flatMap(res => res.status match {
           //  Parse for Tokens if Status.Ok
           case Status.Ok =>
             OAuth2.derive[AadToken](res.contentString).fold[Future[AadToken]](

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/SecretStores.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/SecretStores.scala
@@ -116,7 +116,8 @@ object SecretStores {
     private[this] def processPolledSecrets(secrets: Option[Secrets], result: Boolean): Unit =
       (secrets, result) match {
         case (Some(s), true) =>
-          log.info(s"ConsulSecretStore: Received a new Secret from Consul with an id: ${s.current.id}")
+          log.info("ConsulSecretStore: Received a new Secret from Consul " +
+            s"with an id: ${s.current.id}, expiry: ${s.current.expiry}")
           _secrets = s
           timer.schedule(_secrets.current.expiry)(pollSecrets)
 
@@ -198,8 +199,8 @@ object SecretStores {
           req.contentType = "application/json"
         })).flatMap(res => res.status match {
             case Status.Ok =>
-              log.info("ConsulSecretStore: LEADER: Updated the new Secrets on Consul with an id: " +
-                newSecrets.current.id)
+              log.info("ConsulSecretStore: LEADER: Updated the new Secrets on Consul " +
+                s"with an id: ${newSecrets.current.id}, expiry: ${newSecrets.current.expiry}")
               Future.value((Some(newSecrets), res.contentString == "true"))
             case _ => Future.exception(ConsulError(s"Step-${step}: Failed to set Secrets with an error response " +
               s"from Consul: ${res.status}"))

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
@@ -305,26 +305,6 @@ class OAuth2Spec extends BorderPatrolSuite {
       "http://localhost:9999/tokenUrl with java.net.ConnectException: Connection refused:")
   }
 
-  /** this exception is thrown by codeToToken method in OAuth2CodeProtoManager */
-  it should "throw an Exception on if it receives HTTP request w/ OAuth2 code but without hostname" in {
-    // Allocate and Session
-    val sessionId = sessionid.untagged
-
-    // Login POST request
-    val loginRequest = Request("/signin", ("code" -> "XYZ123"))
-
-    // BorderRequest
-    val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
-
-    // Validate
-    val caught = the[Exception] thrownBy {
-
-      // Execute
-      val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
-    }
-    caught.getMessage should be("Host not found in HTTP Request")
-  }
-
   it should "throw an exception if fails to parse OAuth2 AAD Token in the response" in {
     val server = com.twitter.finagle.Http.serve(
       "localhost:4567", mkTestService[Request, Response] { req =>

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
@@ -56,24 +56,28 @@ object helpers {
 
   //  urls
   val urls = Set(new URL("http://localhost:5678"))
+  val bpPort: Int = 8080
+  val bpExtUrl = new URL("http://localhost:8080")
 
   //  Managers
   val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), urls)
   val keymasterAccessManager = Manager("keymaster", Path("/accessIssuer"), urls)
-  val internalProtoManager = InternalAuthProtoManager(Path("/loginConfirm"), Path("/check"))
+  val internalProtoManager = InternalAuthProtoManager(Path("/loginConfirm"), Path("/check"), None)
   val checkpointLoginManager = LoginManager("checkpoint", keymasterIdManager, keymasterAccessManager,
     internalProtoManager)
-  val oauth2CodeProtoManager = OAuth2CodeProtoManager(Path("/signin"),
+  val oauth2CodeProtoManager = OAuth2CodeProtoManager(bpExtUrl, Path("/signin"),
     new URL("http://example.com/authorizeUrl"),
     new URL("http://localhost:4567/tokenUrl"),
     new URL("http://localhost:4567/certificateUrl"),
+    Some(new URL("http://example.com/loggedOut")),
     "clientId", "clientSecret")
   val umbrellaLoginManager = LoginManager("ulm", keymasterIdManager, keymasterAccessManager,
     oauth2CodeProtoManager)
-  val oauth2CodeBadProtoManager = OAuth2CodeProtoManager(Path("/signblew"),
+  val oauth2CodeBadProtoManager = OAuth2CodeProtoManager(bpExtUrl, Path("/signblew"),
     new URL("http://localhost:9999/authorizeUrl"),
     new URL("http://localhost:9999/tokenUrl"),
     new URL("http://localhost:9999/certificateUrl"),
+    Some(new URL("http://example.com/loggedOut")),
     "clientId", "clientSecret")
   val rainyLoginManager = LoginManager("rlm", keymasterIdManager, keymasterAccessManager,
     oauth2CodeBadProtoManager)

--- a/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
@@ -18,7 +18,7 @@ object BorderPatrolApp extends TwitterServer with Config {
     val statsdReporter = StatsdExporter(serverConfig.statsdExporterConfig)
 
     // Create a server
-    val server1 = Http.serve(":8080", MainServiceChain)
+    val server1 = Http.serve(s":${serverConfig.port}", MainServiceChain)
     val server2 = Http.serve(":8081", getMockRoutingService)
     Await.all(server1, server2)
   }


### PR DESCRIPTION
port - port where each BP node anchors
external endpoint - visible to outside work; E.g. ELB address (and port if necessary)
loggedOut url - after a logout, user is redirected to this URL (in order to add a landing area after SSO logout)