### PR TITLE
Backout externalEndpoint changes committed by pull request 125

### DIFF
--- a/bpConfig.json
+++ b/bpConfig.json
@@ -1,6 +1,5 @@
 {
-  "port": "8080",
-  "externalEndpoint": "http://localhost:8080",
+  "listeningPort": "8080",
   "statsdReporter": {
      "host": "localhost:8125",
      "durationInSec": 60,

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.1.9-SNAPSHOT"
+lazy val Version = "0.1.10-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
@@ -32,7 +32,7 @@ case class LoginManager(name: String, identityManager: Manager, accessManager: M
 trait ProtoManager {
   val loginConfirm: Path
   val loggedOutUrl: Option[URL]
-  def redirectLocation: String
+  def redirectLocation(host: Option[String]): String
   def isMatchingPath(p: Path): Boolean = Set(loginConfirm).filter(p.startsWith(_)).nonEmpty
 }
 
@@ -42,17 +42,16 @@ trait ProtoManager {
  * @param loginConfirm path intercepted by bordetpatrol and internal authentication service posts
  *                     the authentication response on this path
  * @param authorizePath path of the internal authentication service where client is redirected
- * @param loggedOutUrl A url where user is redirected after the Logout
+ * @param loggedOutUrl A Url where user is redirected after the Logout
  */
 case class InternalAuthProtoManager(loginConfirm: Path, authorizePath: Path, loggedOutUrl: Option[URL])
     extends ProtoManager {
-  def redirectLocation: String = authorizePath.toString
+  def redirectLocation(host: Option[String]): String = authorizePath.toString
 }
 
 /**
  * OAuth code framework, that redirects user to OAuth2 server.
  *
- * @param bpExternalEndpoint Externally visible BorderPatrol URL
  * @param loginConfirm path intercepted by borderpatrol and OAuth2 server posts the oAuth2 code on this path
  * @param authorizeUrl URL of the OAuth2 service where client is redirected for authenticaiton
  * @param tokenUrl URL of the OAuth2 server to convert OAuth2 code to OAuth2 token
@@ -61,23 +60,22 @@ case class InternalAuthProtoManager(loginConfirm: Path, authorizePath: Path, log
  * @param clientId Id used for communicating with OAuth2 server
  * @param clientSecret Secret used for communicating with OAuth2 server
  */
-case class OAuth2CodeProtoManager(bpExternalEndpoint: URL, loginConfirm: Path, authorizeUrl: URL, tokenUrl: URL,
-                                  certificateUrl: URL, loggedOutUrl: Option[URL], clientId: String,
-                                  clientSecret: String)
+case class OAuth2CodeProtoManager(loginConfirm: Path, authorizeUrl: URL, tokenUrl: URL, certificateUrl: URL,
+                                  loggedOutUrl: Option[URL], clientId: String, clientSecret: String)
     extends ProtoManager{
   private[this] val log = Logger.get(getClass.getPackage.getName)
 
-  def redirectLocation: String =
+  def redirectLocation(host: Option[String]): String = {
+    val hostStr = host.getOrElse(throw new Exception("Host not found in HTTP Request"))
     Request.queryString(authorizeUrl.toString, ("response_type", "code"), ("state", "foo"),
-      ("client_id", clientId),
-      ("redirect_uri", s"$bpExternalEndpoint$loginConfirm"))
-
-  def codeToToken(code: String): Future[Response] = {
+      ("client_id", clientId), ("redirect_uri", "http://" + hostStr + loginConfirm.toString))
+  }
+  def codeToToken(host: Option[String], code: String): Future[Response] = {
+    val hostStr = host.getOrElse(throw new Exception("Host not found in HTTP Request"))
     val request = util.Combinators.tap(Request(Method.Post, tokenUrl.toString))(re => {
       re.contentType = "application/x-www-form-urlencoded"
       re.contentString = Request.queryString(("grant_type", "authorization_code"), ("client_id", clientId),
-        ("code", code),
-        ("redirect_uri", s"$bpExternalEndpoint$loginConfirm"),
+        ("code", code), ("redirect_uri", "http://" + hostStr + loginConfirm.toString),
         ("client_secret", clientSecret), ("resource", "00000002-0000-0000-c000-000000000000"))
         .drop(1) /* Drop '?' */
     })

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
@@ -161,7 +161,7 @@ case class BorderService(identityProviderMap: Map[String, Service[BorderRequest,
   }
 
   def redirectToLogin(req: SessionIdRequest): Future[Response] = {
-    val path = req.customerId.loginManager.protoManager.redirectLocation
+    val path = req.customerId.loginManager.protoManager.redirectLocation(req.req.host)
     log.debug(s"Redirecting the ${req.req} for Untagged Session: ${req.sessionId.toLogIdString} " +
       s"to login service, location: ${path}")
     redirectTo(path).toFuture

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/OAuth2.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/OAuth2.scala
@@ -151,7 +151,8 @@ object OAuth2 {
      */
     def codeToClaimsSet(req: BorderRequest, protoManager: OAuth2CodeProtoManager): Future[JWTClaimsSet] = {
       for {
-        aadToken <- protoManager.codeToToken(req.req.getParam("code")).flatMap(res => res.status match {
+        aadToken <- protoManager.codeToToken(req.req.host,
+          req.req.getParam("code")).flatMap(res => res.status match {
           //  Parse for Tokens if Status.Ok
           case Status.Ok =>
             OAuth2.derive[AadToken](res.contentString).fold[Future[AadToken]](

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
@@ -508,6 +508,24 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     Await.result(output).location.value should be ("/check")
   }
 
+  it should "throw an exception while attempting a redirect to login and Host is not missing from HTTP Request" in {
+    val testSidBinder = mkTestSidBinder { _ => { fail("TestSidBinder should not be invoked for this test") } }
+
+    //  Allocate and Session
+    val sessionId = sessionid.untagged
+
+    // Create request
+    val request = Request("/umb")
+
+    // Validate
+    val caught = the[Exception] thrownBy {
+      // Execute
+      val output = BorderService(workingMap, workingMap, serviceMatcher, testSidBinder).apply(
+        SessionIdRequest(request, cust2, sessionId))
+    }
+    caught.getMessage should equal("Host not found in HTTP Request")
+  }
+
   it should "return a Status.NotFound if session is authenticated and trying to reach LoginManager confirm" in {
     val testSidBinder = mkTestSidBinder { _ => { fail("TestSidBinder should not be invoked for this test") } }
 

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
@@ -305,6 +305,25 @@ class OAuth2Spec extends BorderPatrolSuite {
       "http://localhost:9999/tokenUrl with java.net.ConnectException: Connection refused:")
   }
 
+  /** this exception is thrown by codeToToken method in OAuth2CodeProtoManager */
+  it should "throw an Exception on if it receives HTTP request w/ OAuth2 code but without hostname" in {
+    // Allocate and Session
+    val sessionId = sessionid.untagged
+
+    // Login POST request
+    val loginRequest = Request("/signin", ("code" -> "XYZ123"))
+
+    // BorderRequest
+    val sessionIdRequest = BorderRequest(loginRequest, cust2, two, sessionId)
+
+    // Validate
+    val caught = the[Exception] thrownBy {
+      // Execute
+      val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
+    }
+    caught.getMessage should be("Host not found in HTTP Request")
+  }
+
   it should "throw an exception if fails to parse OAuth2 AAD Token in the response" in {
     val server = com.twitter.finagle.Http.serve(
       "localhost:4567", mkTestService[Request, Response] { req =>

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
@@ -57,7 +57,6 @@ object helpers {
   //  urls
   val urls = Set(new URL("http://localhost:5678"))
   val bpPort: Int = 8080
-  val bpExtUrl = new URL("http://localhost:8080")
 
   //  Managers
   val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), urls)
@@ -65,7 +64,7 @@ object helpers {
   val internalProtoManager = InternalAuthProtoManager(Path("/loginConfirm"), Path("/check"), None)
   val checkpointLoginManager = LoginManager("checkpoint", keymasterIdManager, keymasterAccessManager,
     internalProtoManager)
-  val oauth2CodeProtoManager = OAuth2CodeProtoManager(bpExtUrl, Path("/signin"),
+  val oauth2CodeProtoManager = OAuth2CodeProtoManager(Path("/signin"),
     new URL("http://example.com/authorizeUrl"),
     new URL("http://localhost:4567/tokenUrl"),
     new URL("http://localhost:4567/certificateUrl"),
@@ -73,7 +72,7 @@ object helpers {
     "clientId", "clientSecret")
   val umbrellaLoginManager = LoginManager("ulm", keymasterIdManager, keymasterAccessManager,
     oauth2CodeProtoManager)
-  val oauth2CodeBadProtoManager = OAuth2CodeProtoManager(bpExtUrl, Path("/signblew"),
+  val oauth2CodeBadProtoManager = OAuth2CodeProtoManager(Path("/signblew"),
     new URL("http://localhost:9999/authorizeUrl"),
     new URL("http://localhost:9999/tokenUrl"),
     new URL("http://localhost:9999/certificateUrl"),

--- a/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
@@ -18,7 +18,7 @@ object BorderPatrolApp extends TwitterServer with Config {
     val statsdReporter = StatsdExporter(serverConfig.statsdExporterConfig)
 
     // Create a server
-    val server1 = Http.serve(s":${serverConfig.port}", MainServiceChain)
+    val server1 = Http.serve(s":${serverConfig.listeningPort}", MainServiceChain)
     val server2 = Http.serve(":8081", getMockRoutingService)
     Await.all(server1, server2)
   }

--- a/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
@@ -37,9 +37,9 @@ class ConfigSpec extends BorderPatrolSuite {
   val defaultStatsdExporterConfig = StatsdExporterConfig("host", 300, "prefix")
 
   // Configs
-  val serverConfig = ServerConfig(bpPort, bpExtUrl, defaultSecretStore, defaultSessionStore, defaultStatsdExporterConfig,
+  val serverConfig = ServerConfig(bpPort, defaultSecretStore, defaultSessionStore, defaultStatsdExporterConfig,
     cids, sids, loginManagers, Set(keymasterIdManager), Set(keymasterAccessManager))
-  val serverConfig1 = ServerConfig(bpPort, bpExtUrl, consulSecretStore, memcachedSessionStore, defaultStatsdExporterConfig,
+  val serverConfig1 = ServerConfig(bpPort, consulSecretStore, memcachedSessionStore, defaultStatsdExporterConfig,
     cids, sids, loginManagers, Set(keymasterIdManager), Set(keymasterAccessManager))
 
   // Verify
@@ -101,7 +101,7 @@ class ConfigSpec extends BorderPatrolSuite {
       val encoded = config.asJson
       decode[ServerConfig](encoded.toString()) match {
         case Xor.Right(a) => a
-        case Xor.Left(b) => ServerConfig(bpPort, bpExtUrl, defaultSecretStore, defaultSessionStore,
+        case Xor.Left(b) => ServerConfig(bpPort, defaultSecretStore, defaultSessionStore,
           defaultStatsdExporterConfig, Set(), Set(), Set(), Set(), Set())
       }
     }
@@ -144,12 +144,11 @@ class ConfigSpec extends BorderPatrolSuite {
     val caught = the [ConfigError] thrownBy {
       readServerConfig(tempInvalidFile.toCanonical.toString)
     }
-    caught.getMessage should include regex ("Failed to decode following fields: port")
+    caught.getMessage should include regex ("Failed to decode following fields: listeningPort")
   }
 
-  it should "raise a ConfigError exception due to lack of BorderPatrol url config" in {
+  it should "raise a ConfigError exception due to lack of listeningPort config" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),
@@ -165,13 +164,12 @@ class ConfigSpec extends BorderPatrolSuite {
     val caught = the [ConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
-    caught.getMessage should include regex ("Failed to decode following fields: externalEndpoint")
+    caught.getMessage should include regex ("Failed to decode following fields: listeningPort")
   }
 
   it should "raise a ConfigError exception due to lack of Secret Store config" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
-      ("externalEndpoint", bpExtUrl.asJson),
+      ("listeningPort", bpPort.asJson),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),
       ("customerIdentifiers", cids.asJson),
@@ -191,8 +189,7 @@ class ConfigSpec extends BorderPatrolSuite {
 
   it should "raise a ConfigError exception due to invalid of Secret Store config" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
-      ("externalEndpoint", bpExtUrl.asJson),
+      ("listeningPort", bpPort.asJson),
       ("secretStore", Json.obj(("type", Json.string("woof")))),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),
@@ -213,8 +210,7 @@ class ConfigSpec extends BorderPatrolSuite {
 
   it should "raise a ConfigError exception due to lack of Session Store config" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
-      ("externalEndpoint", bpExtUrl.asJson),
+      ("listeningPort", bpPort.asJson),
       ("secretStore", consulSecretStore.asInstanceOf[SecretStoreApi].asJson),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),
       ("customerIdentifiers", cids.asJson),
@@ -234,8 +230,7 @@ class ConfigSpec extends BorderPatrolSuite {
 
   it should "raise a ConfigError exception due to invalid Session Store config" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
-      ("externalEndpoint", bpExtUrl.asJson),
+      ("listeningPort", bpPort.asJson),
       ("secretStore", consulSecretStore.asInstanceOf[SecretStoreApi].asJson),
       ("sessionStore", Json.obj(("type", Json.string("woof")))),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),
@@ -256,8 +251,7 @@ class ConfigSpec extends BorderPatrolSuite {
 
   it should "raise a ConfigError exception due to lack of Statsd Reporter config" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
-      ("externalEndpoint", bpExtUrl.asJson),
+      ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
       ("customerIdentifiers", cids.asJson),
@@ -272,13 +266,12 @@ class ConfigSpec extends BorderPatrolSuite {
     val caught = the [ConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
-    caught.getMessage should include regex ("Failed to decode following fields: port, statsdReporter")
+    caught.getMessage should include regex ("Failed to decode following fields: statsdReporter")
   }
 
   it should "raise a ConfigError exception due to lack of CustomerIdentifier config" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
-      ("externalEndpoint", bpExtUrl.asJson),
+      ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),
@@ -298,8 +291,7 @@ class ConfigSpec extends BorderPatrolSuite {
 
   it should "raise a ConfigError exception due to lack of ServiceIdentifier config" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
-      ("externalEndpoint", bpExtUrl.asJson),
+      ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),
@@ -319,8 +311,7 @@ class ConfigSpec extends BorderPatrolSuite {
 
   it should "raise a ConfigError exception if identityManager that is used in LoginManager is missing" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
-      ("externalEndpoint", bpExtUrl.asJson),
+      ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),
@@ -341,8 +332,7 @@ class ConfigSpec extends BorderPatrolSuite {
 
   it should "raise a ConfigError exception if duplicate are configured in idManagers config" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
-      ("externalEndpoint", bpExtUrl.asJson),
+      ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),
@@ -364,8 +354,7 @@ class ConfigSpec extends BorderPatrolSuite {
 
   it should "raise a ConfigError exception if accessManager that is used in LoginManager is missing" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
-      ("externalEndpoint", bpExtUrl.asJson),
+      ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),
@@ -386,8 +375,7 @@ class ConfigSpec extends BorderPatrolSuite {
 
   it should "raise a ConfigError exception if duplicates are configured in accessManagers config" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
-      ("externalEndpoint", bpExtUrl.asJson),
+      ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),
@@ -409,8 +397,7 @@ class ConfigSpec extends BorderPatrolSuite {
 
   it should "raise a ConfigError exception if duplicates are configured in loginManagers config" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
-      ("externalEndpoint", bpExtUrl.asJson),
+      ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),
@@ -433,8 +420,7 @@ class ConfigSpec extends BorderPatrolSuite {
 
   it should "raise a ConfigError exception if duplicate names are configured in serviceIdentifiers config" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
-      ("externalEndpoint", bpExtUrl.asJson),
+      ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),
@@ -456,8 +442,7 @@ class ConfigSpec extends BorderPatrolSuite {
 
   it should "raise a ConfigError exception if duplicate paths are configured in serviceIdentifiers config" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
-      ("externalEndpoint", bpExtUrl.asJson),
+      ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),
@@ -479,8 +464,7 @@ class ConfigSpec extends BorderPatrolSuite {
 
   it should "raise a ConfigError exception if duplicate subdomains are configured in customerIdentifiers config" in {
     val partialContents = Json.fromFields(Seq(
-      ("port", bpPort.asJson),
-      ("externalEndpoint", bpExtUrl.asJson),
+      ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),


### PR DESCRIPTION
Backout the `externalEndpoint` configuration, because external subdomain will be different for each tenant. Instead we should keep relying on `req.host`; but we eventually need to resolve what protocol (http or https) to use for redirect.