### PR TITLE
Show all config validation errors at once

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Credential.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Credential.scala
@@ -3,6 +3,7 @@ package com.lookout.borderpatrol.auth.keymaster
 import com.lookout.borderpatrol.{CustomerIdentifier, ServiceIdentifier}
 import com.lookout.borderpatrol.util.Combinators._
 import com.twitter.finagle.http.{Method, Request}
+import com.twitter.logging.Logger
 
 
 trait Credential {
@@ -26,11 +27,15 @@ case class InternalAuthCredential(uniqueId: String, password: String, customerId
 case class OAuth2CodeCredential(uniqueId: String, subject: String, customerId: CustomerIdentifier,
                                 serviceId: ServiceIdentifier)
     extends Credential {
+  private[this] val log = Logger.get(getClass.getPackage.getName)
+
   def toRequest: Request =
     tap(Request(Method.Post, customerId.loginManager.identityManager.path.toString))(req => {
       req.contentType = "application/x-www-form-urlencoded"
       req.contentString = Request.queryString(("s", serviceId.name), ("external_id", subject),
         ("ident_provider", customerId.loginManager.name), ("enterprise", customerId.subdomain))
         .drop(1) /* Drop '?' */
+      log.info(s"Authenticating OAuth2 user: $uniqueId " +
+        s"and external_id: $subject with Keymaster IdentityProvider")
     })
 }

--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
@@ -51,7 +51,6 @@ object Keymaster {
      */
     def apply(req: IdentifyRequest[Credential]): Future[IdentifyResponse[Tokens]] = {
       requestSends.incr
-      log.debug(s"Authenticating user: ${req.credential.uniqueId} with Keymaster IdentityProvider")
 
       //  Authenticate user by the Keymaster
       binder(BindRequest(req.credential.customerId.loginManager.identityManager, req.credential.toRequest))
@@ -86,7 +85,6 @@ object Keymaster {
    */
   case class KeymasterTransformFilter(oAuth2CodeVerify: OAuth2CodeVerify)(implicit statsReceiver: StatsReceiver)
       extends Filter[BorderRequest, Response, KeymasterIdentifyReq, Response] {
-    private[this] val log = Logger.get(getClass.getPackage.getName)
 
     def transformInternal(req: BorderRequest): Future[InternalAuthCredential] =
       (for {

--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
@@ -51,6 +51,7 @@ object Keymaster {
      */
     def apply(req: IdentifyRequest[Credential]): Future[IdentifyResponse[Tokens]] = {
       requestSends.incr
+      log.debug(s"Authenticating user: ${req.credential.uniqueId} with Keymaster IdentityProvider")
 
       //  Authenticate user by the Keymaster
       binder(BindRequest(req.credential.customerId.loginManager.identityManager, req.credential.toRequest))
@@ -70,7 +71,7 @@ object Keymaster {
           )
         //  Preserve Response Status code by throwing AccessDenied exceptions
         case _ => {
-          log.debug(s"IdentityProvider denied user: ${req.credential.uniqueId} " +
+          log.debug(s"Keymaster IdentityProvider denied user: ${req.credential.uniqueId} " +
             s"with status: ${res.status}")
           responseFailed.incr
           Future.exception(IdentityProviderError(res.status,

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.1.10-SNAPSHOT"
+lazy val Version = "0.1.11-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
@@ -311,7 +311,7 @@ class ConfigSpec extends BorderPatrolSuite {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include (
-      "LoginManager - bad - not found:failed to decode following field(s): customerIdentifiers")
+      "LoginManager \"bad\" not found:failed to decode following field(s): customerIdentifiers")
   }
 
   it should "raise a ConfigError exception due to missing ServiceIdentifier in CustomerIdentifier config" in {
@@ -336,7 +336,7 @@ class ConfigSpec extends BorderPatrolSuite {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include (
-      "ServiceIdentifier - bad - not found:failed to decode following field(s): customerIdentifiers")
+      "ServiceIdentifier \"bad\" not found:failed to decode following field(s): customerIdentifiers")
   }
 
   it should "raise a ConfigError exception due to lack of ServiceIdentifier config" in {
@@ -378,7 +378,7 @@ class ConfigSpec extends BorderPatrolSuite {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include (
-      "IdentityManager - keymaster - not found:failed to decode following field(s): loginManagers")
+      "IdentityManager \"keymaster\" not found:failed to decode following field(s): loginManagers")
   }
 
   it should "raise a ConfigError exception if duplicate are configured in idManagers config" in {
@@ -422,7 +422,7 @@ class ConfigSpec extends BorderPatrolSuite {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include (
-      "AccessManager - keymaster - not found:failed to decode following field(s): loginManagers")
+      "AccessManager \"keymaster\" not found:failed to decode following field(s): loginManagers")
   }
 
   it should "raise a ConfigError exception if duplicates are configured in accessManagers config" in {


### PR DESCRIPTION
Currently, config validation stops at first error. Instead we should display
all the errors at once, for better experience.

Also, error messages are vague (i.e. failed to decode following fields:
CustomerIdentifier). It should display actual error message that caused the parsing
failure (albeit in some cases).

Fixes #127