### PR TITLE
Split BorderService into seperate filters

### DIFF
--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/TokensSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/TokensSpec.scala
@@ -20,6 +20,19 @@ class TokensSpec extends BorderPatrolSuite  {
   val tokens = Tokens(masterToken, serviceTokens)
   val emptyTokens = Tokens(MasterToken(""), ServiceTokens())
 
+  behavior of "ServiceToken"
+
+  it should "uphold encoding/decoding ServiceToken" in {
+    def encodeDecode(sTok: ServiceToken) : ServiceToken = {
+      val encoded = sTok.asJson
+      derive[ServiceToken](encoded.toString) match {
+        case Xor.Right(a) => a
+        case Xor.Left(b) => new ServiceToken("failed")
+      }
+    }
+    encodeDecode(serviceToken1) should be (serviceToken1)
+  }
+
   behavior of "ServiceTokens"
 
   it should "be able to find ServiceToken by service name" in {

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.1.12-SNAPSHOT"
+lazy val Version = "0.1.13-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
@@ -33,7 +33,6 @@ trait ProtoManager {
   val loginConfirm: Path
   val loggedOutUrl: Option[URL]
   def redirectLocation(host: Option[String]): String
-  def isMatchingPath(p: Path): Boolean = Set(loginConfirm).filter(p.startsWith(_)).nonEmpty
 }
 
 /**

--- a/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
@@ -29,7 +29,4 @@ case class ServiceIdentifier(name: String, hosts: Set[URL], path: Path, rewriteP
  * @param defaultServiceId
  * @param loginManager
  */
-case class CustomerIdentifier(subdomain: String, defaultServiceId: ServiceIdentifier, loginManager: LoginManager) {
-  def isLoginManagerPath(p: Path): Boolean =
-    loginManager.protoManager.isMatchingPath(p)
-}
+case class CustomerIdentifier(subdomain: String, defaultServiceId: ServiceIdentifier, loginManager: LoginManager)

--- a/core/src/test/scala/com/lookout/borderpatrol/test/ServiceMatcherSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/ServiceMatcherSpec.scala
@@ -3,6 +3,7 @@ package com.lookout.borderpatrol.test
 import com.lookout.borderpatrol._
 import com.twitter.finagle.http.path.Path
 
+
 class ServiceMatcherSpec extends BorderPatrolSuite {
   import sessionx.helpers._
 
@@ -19,49 +20,26 @@ class ServiceMatcherSpec extends BorderPatrolSuite {
   val custIds = Set(cOne, cTwo, cThree, cFour)
   val testServiceMatcher = ServiceMatcher(custIds, serviceIds)
 
-  def getWinner(cid: CustomerIdentifier, sid: ServiceIdentifier): (CustomerIdentifier, ServiceIdentifier) =
-    testServiceMatcher.get(req(cid.subdomain, sid.path.toString)).value
-
   behavior of "ServiceMatchers"
 
   it should "match the longest path" in {
-    testServiceMatcher.path(Path("/")) should be(None)
-    testServiceMatcher.path(Path("/e")) should be(None)
-    testServiceMatcher.path(Path("/ent")) should be(None)
-    testServiceMatcher.path(Path("/ent1/blah")).value should be(sOneOne)
-    testServiceMatcher.path(Path("/ent2")).value should be(sOneTwo)
-    testServiceMatcher.path(Path("/api")).value should be(sTwo)
-    testServiceMatcher.path(Path("/apis")).value should be(sThree)
-    testServiceMatcher.path(Path("/apis/testing")).value should be(sThree)
-    testServiceMatcher.path(Path("/apis/test")).value should be(sFour)
+    testServiceMatcher.serviceId(Path("/")) should be(None)
+    testServiceMatcher.serviceId(Path("/e")) should be(None)
+    testServiceMatcher.serviceId(Path("/ent")) should be(None)
+    testServiceMatcher.serviceId(Path("/ent1/blah")).value should be(sOneOne)
+    testServiceMatcher.serviceId(Path("/ent2")).value should be(sOneTwo)
+    testServiceMatcher.serviceId(Path("/api")).value should be(sTwo)
+    testServiceMatcher.serviceId(Path("/apis")).value should be(sThree)
+    testServiceMatcher.serviceId(Path("/apis/testing")).value should be(sThree)
+    testServiceMatcher.serviceId(Path("/apis/test")).value should be(sFour)
   }
 
   it should "match the longest subdomain" in {
-    testServiceMatcher.subdomain("www.example.com") should be(None)
-    testServiceMatcher.subdomain("enterprise.api.example.com").value should be(cOne)
-    testServiceMatcher.subdomain("enterprise.example.com").value should be(cOne)
-    testServiceMatcher.subdomain("api.example.com").value should be(cTwo)
-    testServiceMatcher.subdomain("api.subdomains.example.com").value should be(cTwo)
-    testServiceMatcher.subdomain("api.subdomain.example.com").value should be(cThree)
-  }
-
-  it should "match the longest get" in {
-    testServiceMatcher.get(req("enterprise", "/")).value should be((cOne, sOneOne))
-    testServiceMatcher.get(req("enterprise", "/ent2")).value should be((cOne, sOneTwo))
-    testServiceMatcher.get(req("enterprise", "/check")) should be(None)
-    testServiceMatcher.get(req("enterprise", "/loginConfirm")).value should be((cOne, sOneOne))
-    testServiceMatcher.get(req("api", "/check")) should be(None)
-    testServiceMatcher.get(req("api", "/loginConfirm")) should be(None)
-    testServiceMatcher.get(req("api.testdomain", "/apis/test")).value should be((cFour, sFour))
-    testServiceMatcher.get(req("api.testdomain", "/signin")).value should be((cFour, sFour))
-    testServiceMatcher.get(req("api.testdomain", "/login")) should be(None)
-  }
-
-  it should "match the given ServiceIdentifier with itself" in {
-    val permutations = for {
-      cid <- custIds.toList
-      sid <- serviceIds.toList
-    } yield getWinner(cid, sid) == Tuple2(cid, sid)
-    permutations.foreach(p => p should be(true))
+    testServiceMatcher.customerId("www.example.com") should be(None)
+    testServiceMatcher.customerId("enterprise.api.example.com").value should be(cOne)
+    testServiceMatcher.customerId("enterprise.example.com").value should be(cOne)
+    testServiceMatcher.customerId("api.example.com").value should be(cTwo)
+    testServiceMatcher.customerId("api.subdomains.example.com").value should be(cTwo)
+    testServiceMatcher.customerId("api.subdomain.example.com").value should be(cThree)
   }
 }

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
@@ -9,6 +9,7 @@ import com.lookout.borderpatrol.sessionx.SecretStores.InMemorySecretStore
 import com.twitter.finagle.http.path.Path
 import com.twitter.finagle.http.{RequestBuilder, Response, Request}
 import com.twitter.finagle.stats.NullStatsReceiver
+import com.twitter.io.Buf
 import com.twitter.util._
 import com.twitter.finagle.Service
 import com.twitter.bijection.Injection
@@ -107,6 +108,9 @@ object helpers {
   // Request helper
   def req(subdomain: String, path: String, params: Tuple2[String, String]*): Request =
     RequestBuilder().url(s"http://${subdomain + "."}example.com${Request.queryString(path, params:_*)}").buildGet()
+  def reqPost(subdomain: String, path: String, content: Buf, params: Tuple2[String, String]*): Request =
+    RequestBuilder().url(s"http://${subdomain + "."}example.com${Request.queryString(path, params:_*)}")
+      .buildPost(content)
 
   // Binders
   case class TestManagerBinder() extends MBinder[Manager]


### PR DESCRIPTION
- Split into IdentityService, AccessIssuer and UnprotectedService filters
- Allow POST to loginConfirm w/o sessionId to continue with authentication

Fixes #130