### PR TITLE
Add support for application/JSON calls in BP2

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Tokens.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Tokens.scala
@@ -1,6 +1,6 @@
 package com.lookout.borderpatrol.auth.keymaster
 
-import com.lookout.borderpatrol.sessionx.{SessionDataError, SessionDataEncoder}
+import com.lookout.borderpatrol.sessionx.{BpSessionDataError, SessionDataEncoder}
 import com.twitter.io.Buf
 import io.circe._
 import io.circe.generic.auto._
@@ -135,7 +135,7 @@ object Tokens {
     def decode(buf: Buf): Try[Tokens] =
       SessionDataEncoder.encodeString.decode(buf).flatMap(s =>
         derive[Tokens](s).fold[Try[Tokens]](
-          e => Failure(SessionDataError(e)),
+          e => Failure(BpSessionDataError(e)),
           t => Success(t)
         )
       )

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
@@ -4,6 +4,7 @@ import com.lookout.borderpatrol.BinderBase
 import com.lookout.borderpatrol.auth.OAuth2.OAuth2CodeVerify
 import com.lookout.borderpatrol.auth.keymaster.Keymaster._
 import com.lookout.borderpatrol.auth._
+import com.lookout.borderpatrol.errors.{BadRequest, ForbiddenRequest}
 import com.lookout.borderpatrol.sessionx.SessionStores.MemcachedStore
 import com.lookout.borderpatrol.sessionx._
 import com.lookout.borderpatrol.test._
@@ -45,13 +46,6 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
       case EmptyIdentity => null
     })
 
-  // Method to decode SessionData from the sessionId in Response
-  def sessionDataFromResponse(resp: Response): Future[Tokens] =
-    for {
-      sessionId <- SignedId.fromResponse(resp).toFuture
-      toks <- getTokensFromSessionId(sessionId)
-    } yield toks
-
   val keymasterLoginFilterTestService = mkTestService[IdentifyRequest[Credential], IdentifyResponse[Tokens]] {
     req => Future(KeymasterIdentifyRes(tokens)) }
 
@@ -83,8 +77,8 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     Await.result(output).identity should be (Id(tokens))
   }
 
-  it should "propagate the error Status code from Keymaster service in the IdentityProviderError exception" in {
-    val testIdentityManagerBinder = mkTestManagerBinder { request => Response(Status.NotFound).toFuture }
+  it should "propagate the error Status code from Keymaster service in the BpIdentityProviderError exception" in {
+    val testIdentityManagerBinder = mkTestManagerBinder { request => Response(Status.Forbidden).toFuture }
 
     // Allocate and Session
     val sessionId = sessionid.untagged
@@ -100,14 +94,14 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
       KeymasterIdentifyReq(sessionIdRequest, OAuth2CodeCredential("foo", "bar", cust2, two)))
 
     // Validate
-    val caught = the [IdentityProviderError] thrownBy {
+    val caught = the [BpIdentityProviderError] thrownBy {
       Await.result(output)
     }
-    caught.getMessage should equal ("Invalid credentials for user foo")
-    caught.status should be (Status.NotFound)
+    caught.getMessage should include ("IdentityProvider denied user: foo")
+    caught.status should be (Status.Forbidden)
   }
 
-  it should "propagate the failure parsing the resp from Keymaster service as an IdentityProviderError exception" in {
+  it should "propagate the failure parsing the resp from Keymaster service as an BpTokenParsingError exception" in {
     val testIdentityManagerBinder = mkTestManagerBinder {
       request => tap(Response(Status.Ok))(res => {
         res.contentString = """{"key":"data"}"""
@@ -129,11 +123,10 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
       KeymasterIdentifyReq(sessionIdRequest, InternalAuthCredential("foo", "bar", cust1, one)))
 
     // Validate
-    val caught = the [IdentityProviderError] thrownBy {
+    val caught = the [BpTokenParsingError] thrownBy {
       Await.result(output)
     }
-    caught.getMessage should equal ("Failed to parse the Keymaster Identity Response")
-    caught.status should be (Status.InternalServerError)
+    caught.getMessage should include ("Failed to parse token with: ")
   }
 
   behavior of "KeymasterTransformFilter"
@@ -214,10 +207,10 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
       BorderRequest(loginRequest, cust1, one, sessionId))
 
     // Validate
-    val caught = the [IdentityProviderError] thrownBy {
+    val caught = the [BadRequest] thrownBy {
       Await.result(output)
     }
-    caught.getMessage should equal ("transformBasic: Failed to parse the Request")
+    caught.getMessage should include ("Failed to find username and/or password in the Request")
   }
 
   behavior of "KeymasterPostLoginFilter"
@@ -247,13 +240,16 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
       KeymasterIdentifyReq(BorderRequest(loginRequest, cust1, one, sessionId), credential))
 
     // Validate
-    Await.result(output).status should be (Status.Found)
-    Await.result(output).location should be equals ("/dang")
-    val returnedSessionId = SignedId.fromResponse(Await.result(output)).toFuture
-    returnedSessionId should not be sessionId
-    val session_d = sessionStore.get[Tokens](Await.result(returnedSessionId))
-    val tokensz = sessionDataFromResponse(Await.result(output))
-    Await.result(tokensz) should be (tokens)
+    val caught = the [BpRedirectError] thrownBy {
+      Await.result(output)
+    }
+
+    // Validate
+    caught.status should be(Status.Ok)
+    caught.location should be equals ("/dang")
+    caught.sessionId should not be sessionId
+    val tokensz = getTokensFromSessionId(caught.sessionId)
+    Await.result(tokensz) should be(tokens)
   }
 
   it should "succeed and saves tokens for AAD auth, sends redirect with tokens returned by keymaster IDP" in {
@@ -281,16 +277,19 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
       KeymasterIdentifyReq(BorderRequest(loginRequest, cust2, two, sessionId), credential))
 
     // Validate
-    Await.result(output).status should be(Status.Found)
-    Await.result(output).location should be equals ("/umb")
-    val returnedSessionId = SignedId.fromResponse(Await.result(output)).toFuture
-    returnedSessionId should not be sessionId
-    val session_d = sessionStore.get[Tokens](Await.result(returnedSessionId))
-    val tokensz = sessionDataFromResponse(Await.result(output))
+    val caught = the [BpRedirectError] thrownBy {
+      Await.result(output)
+    }
+
+    // Validate
+    caught.status should be(Status.Ok)
+    caught.location should be equals ("/umb")
+    caught.sessionId should not be sessionId
+    val tokensz = getTokensFromSessionId(caught.sessionId)
     Await.result(tokensz) should be(tokens)
   }
 
-  it should "return OriginalRequestNotFound if it fails find the original request from sessionStore" in {
+  it should "return BpOriginalRequestNotFound if it fails find the original request from sessionStore" in {
     // Allocate and Session
     val sessionId = sessionid.untagged
 
@@ -305,7 +304,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
       KeymasterIdentifyReq(BorderRequest(loginRequest, cust1, one, sessionId), credential))
 
     // Validate
-    val caught = the [OriginalRequestNotFound] thrownBy {
+    val caught = the [BpOriginalRequestNotFound] thrownBy {
       Await.result(output)
     }
   }
@@ -378,7 +377,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     Await.result(tokIt) should be (tokens2)
   }
 
-  it should "propagate the error Status code returned by the Keymaster service, as the AccessIssuerError exception" in {
+  it should "propagate the error Status code returned by the Keymaster service, as the BpAccessIssuerError exception" in {
     val testAccessManagerBinder = mkTestManagerBinder { request => Response(Status.NotFound).toFuture }
     val sessionId = sessionid.untagged
 
@@ -387,14 +386,15 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
       KeymasterAccessReq(Id(tokens), cust1, one, sessionId))
 
     // Validate
-    val caught = the [AccessIssuerError] thrownBy {
+    val caught = the [BpAccessIssuerError] thrownBy {
       Await.result(output)
     }
-    caught.getMessage should equal ("No access allowed to service one due to error: Status(404)")
-    caught.status should be (Status.NotFound)
+    caught.getMessage should include ("AccessIssuer denied access to service: ")
+    caught.getMessage should include (s"${Status.NotFound.code}")
+    caught.status should be (Status.InternalServerError)
   }
 
-  it should "propagate the failure to parse resp content from Keymaster service, as AccessIssuerError exception" in {
+  it should "propagate the failure to parse resp content from Keymaster service, as BpAccessIssuerError exception" in {
     val testAccessManagerBinder = mkTestManagerBinder {
       request => tap(Response(Status.Ok))(res => {
         res.contentString = "invalid string"
@@ -408,10 +408,10 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
       KeymasterAccessReq(Id(tokens), cust1, one, sessionId))
 
     // Validate
-    val caught = the [AccessIssuerError] thrownBy {
+    val caught = the [BpTokenParsingError] thrownBy {
       Await.result(output)
     }
-    caught.getMessage should equal ("Failed to parse the Keymaster Access Response")
+    caught.getMessage should include ("Failed to parse token with: Failed to parse the Keymaster Access Response")
   }
 
   it should "return an AccessDenied exception, if it fails to find the ServiceToken in the Keymaster response" in {
@@ -428,11 +428,11 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
       KeymasterAccessReq(Id(tokens), cust1, one, sessionId))
 
     // Validate
-    val caught = the [AccessDenied] thrownBy {
+    val caught = the [ForbiddenRequest] thrownBy {
       Await.result(output)
     }
-    caught.getMessage should equal ("No access allowed to service one")
-    caught.status should be (Status.NotAcceptable)
+    caught.getMessage should include ("Access not allowed to service:")
+    caught.status should be (Status.Forbidden)
   }
 
   behavior of "AccessFilter"
@@ -547,7 +547,11 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
         BorderRequest(loginRequest, cust1, one, sessionId))
 
       // Validate
-      Await.result(output).status should be(Status.Found)
+      val caught = the [BpRedirectError] thrownBy {
+        Await.result(output)
+      }
+      caught.status should be (Status.Ok)
+
     } finally {
       server.close()
     }

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/TokensSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/TokensSpec.scala
@@ -111,7 +111,7 @@ class TokensSpec extends BorderPatrolSuite  {
     val e = invalid(SessionDataEncoder.encodeString.encode( """{ "a" : "b" }""")).failure.exception
 
     // Validate
-    e should be(a[SessionDataError])
+    e should be(a[BpSessionDataError])
     e.getMessage should include ("Failed to decode into Tokens:")
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.1.13-SNAPSHOT"
+lazy val Version = "0.1.14-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
@@ -100,11 +100,9 @@ object BinderBase {
       cl <- getOrCreate(name, urls)
       res <- cl.apply(request)
     } yield res) handle {
-      case e => {
-        log.warning("Failed to connect " +
-          s"for: $name to: ${urls.map(u => u.getAuthority).mkString(",")} with: ${e.getMessage}")
-        throw CommunicationError(s"${name} with ${e.getMessage}")
-      }
+      case e =>
+        throw BpCommunicationError(s"Failed to connect for: $name " +
+          s"to: ${urls.map(u => u.getAuthority).mkString(",")} with: ${e.getMessage}")
     }
   }
 

--- a/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Binder.scala
@@ -101,7 +101,7 @@ object BinderBase {
       res <- cl.apply(request)
     } yield res) handle {
       case e =>
-        throw BpCommunicationError(s"Failed to connect for: $name " +
+        throw BpCommunicationError(s"Failed to connect for: '${name}' " +
           s"to: ${urls.map(u => u.getAuthority).mkString(",")} with: ${e.getMessage}")
     }
   }

--- a/core/src/main/scala/com/lookout/borderpatrol/Errors.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Errors.scala
@@ -1,7 +1,7 @@
 package com.lookout.borderpatrol
 
 // scalastyle:off null
-class BpBaseError(val message: String) extends Exception(s"BPBASE: $message", null)
+class BpCoreError(val message: String) extends Exception(s"BPCORE: $message", null)
 
 case class BpCommunicationError(error: String)
-  extends BpBaseError(s"An error occurred while talking to: $error")
+  extends BpCoreError(s"An error occurred while talking to: $error")

--- a/core/src/main/scala/com/lookout/borderpatrol/Errors.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Errors.scala
@@ -1,9 +1,7 @@
 package com.lookout.borderpatrol
 
-class BaseError(val message: String, cause: Throwable) extends Exception(message, cause) {
-  // scalastyle:off null
-  def this(message: String) = this(message, null)
-}
+// scalastyle:off null
+class BpBaseError(val message: String) extends Exception(s"BPBASE: $message", null)
 
-case class CommunicationError(error: String)
-  extends BaseError(s"An error occurred while talking to: $error")
+case class BpCommunicationError(error: String)
+  extends BpBaseError(s"An error occurred while talking to: $error")

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
@@ -354,8 +354,8 @@ case class ExceptionFilter() extends SimpleFilter[Request, Response] {
   }
 
   /* Convert a redirect into a response palatable to the client */
-  private[this] def warningAndRedirectResponse(req: Request, error: BpRedirectError): Response = {
-    log.warning(error.msg)
+  private[this] def infoAndRedirectResponse(req: Request, error: BpRedirectError): Response = {
+    log.info(error.msg)
     tap(Response())(res => {
       res.addCookie(error.sessionId.asCookie())
       // If Accept Header contains "application/json", then encode response in JSON format
@@ -375,7 +375,7 @@ case class ExceptionFilter() extends SimpleFilter[Request, Response] {
   }
 
   /* Convert this error into a response appropriate to the client */
-  private[this] def warningAndLogoutResponse(req: Request, error: BpLogoutError): Response = {
+  private[this] def infoAndLogoutResponse(req: Request, error: BpLogoutError): Response = {
     log.info(error.msg)
     tap(Response())(res => {
       // Expire all BP cookies present in the Request
@@ -405,8 +405,8 @@ case class ExceptionFilter() extends SimpleFilter[Request, Response] {
   def errorHandler(req: Request): PartialFunction[Throwable, Response] = {
     case error: BpAccessIssuerError => warningAndResponse(req, error.getMessage, error.status)
     case error: BpIdentityProviderError => warningAndResponse(req, error.getMessage, error.status)
-    case error: BpRedirectError => warningAndRedirectResponse(req, error)
-    case error: BpLogoutError => warningAndLogoutResponse(req, error)
+    case error: BpRedirectError => infoAndRedirectResponse(req, error)
+    case error: BpLogoutError => infoAndLogoutResponse(req, error)
     case error: BpBorderError => warningAndResponse(req, error.getMessage, error.status)
     case error: BpCoreError => warningAndResponse(req, error.getMessage, Status.InternalServerError)
     case error: BpSessionError => warningAndResponse(req, error.getMessage, Status.InternalServerError)

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/Errors.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/Errors.scala
@@ -1,42 +1,46 @@
 package com.lookout.borderpatrol.auth
 
-import com.lookout.borderpatrol.ServiceIdentifier
+import com.lookout.borderpatrol.sessionx.SignedId
 import com.twitter.finagle.http.Status
 
-class AuthError(val message: String, cause: Throwable) extends Exception(message, cause) {
-  // scalastyle:off null
-  def this(message: String) = this(message, null)
-}
 
-/**
- * A response to the user that informs them what to do next when they try to access a protected resource
- * Example: In the case of SAML it would be an http redirect to their IdP
- */
-case class IdentityRequired(id: ServiceIdentifier, cause: Throwable = new Exception) extends AuthError("", cause)
-
-/**
- * This exception stores the response code
- */
-case class AccessDenied(status: Status, msg: String) extends AuthError(msg, null)
-
-/**
- * This exception stores the response code
- */
-case class IdentityProviderError(status: Status, msg: String) extends AuthError(msg, null)
-
-/**
- * This exception stores the response code
- */
-case class AccessIssuerError(status: Status, msg: String) extends AuthError(msg, null)
+// scalastyle:off null
+class BpAuthError(val message: String) extends Exception(s"BPAUTH: $message", null)
 
 /**
  * Token Parsing error
  */
 case class BpTokenParsingError(msg: String)
-    extends AuthError(s"Failed to parse token with: ${msg}", null)
+    extends BpAuthError(s"Failed to parse token with: $msg")
 
 /**
  * Certificate processing error
  */
 case class BpCertificateError(msg: String)
-    extends AuthError(s"Failed to process Certificate with: ${msg}}", null)
+    extends BpAuthError(s"Failed to process Certificate with: $msg}")
+
+/**
+ * Certificate processing error
+ */
+case class BpVerifyTokenError(msg: String)
+  extends BpAuthError(s"Failed to verify the signature on the token: $msg}")
+
+/**
+ * This exception stores the response code
+ */
+case class BpIdentityProviderError(status: Status, msg: String) extends BpAuthError(msg)
+
+/**
+ * This exception stores the response code
+ */
+case class BpAccessIssuerError(status: Status, msg: String) extends BpAuthError(msg)
+
+/**
+ * This exception stores the response code
+ */
+case class BpRedirectError(status: Status, location: String, sessionId: SignedId, msg: String) extends BpAuthError(msg)
+
+/**
+ * This exception stores the response code
+ */
+case class BpLogoutError(status: Status, location: String, msg: String) extends BpAuthError(msg)

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/Identity.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/Identity.scala
@@ -6,19 +6,6 @@ import com.twitter.finagle.Service
  * The purpose of this abstraction to return some input from a user or entity that can be transformed into an
  * understandable identity to be used in the `AccessRequest`. There is no requirement that the identity from the
  * identifier service be the same as the one sent to the access issuer, however, you must supply a transformation.
- *
- * Use case:
- *
- * SAML:
- *  Issue an `IdentityRequired` if there is no valid session, redirecting to the user's IdP
- *  Have an endpoint that recieves the POST with `IdentifyResponse[SamlToken]`
- *  Hand off the `Identity[SamlToken]` to the `AccessIssuer`
- *
- * Internal Identity Provider:
- *  Issue an `IdentityRequired` if there is no valid session, redirect to the login service
- *  Intercept the POST with credentials and forward them to the `IdentityProvider`
- *  Receive a `IdentifyResponse[?]` directly from the `IdentityProvider`
- *  Hand off the `Identity` to the `AccessIssuer`
  */
 
 /**

--- a/core/src/main/scala/com/lookout/borderpatrol/crypto/Cryptable.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/crypto/Cryptable.scala
@@ -1,6 +1,6 @@
 package com.lookout.borderpatrol.crypto
 
-import com.lookout.borderpatrol.sessionx.{SessionDataError, SessionDataEncoder, Session, SignedId}
+import com.lookout.borderpatrol.sessionx.{BpSessionDataError, SessionDataEncoder, Session, SignedId}
 import com.twitter.io.Buf
 
 import scala.util.Try

--- a/core/src/main/scala/com/lookout/borderpatrol/package.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/package.scala
@@ -56,11 +56,10 @@ package object borderpatrol {
   }
 
   object errors {
-    class BorderError(val status: http.Status, val description: String) extends Exception(description)
-    class NotFoundRequest(description: String = "") extends BorderError(http.Status.NotFound, description)
-    class BadRequest(description: String = "") extends BorderError(http.Status.BadRequest, description)
-    class UnauthorizedRequest(description: String = "") extends BorderError(http.Status.Unauthorized, description)
-    class ForbiddenRequest(description: String = "") extends BorderError(http.Status.Forbidden, description)
+    class BpBorderError(val status: http.Status, val description: String) extends Exception(description)
+    class BpNotFoundRequest(description: String = "") extends BpBorderError(http.Status.NotFound, description)
+    class BpBadRequest(description: String = "") extends BpBorderError(http.Status.BadRequest, description)
+    class BpForbiddenRequest(description: String = "") extends BpBorderError(http.Status.Forbidden, description)
   }
 
   object request {

--- a/core/src/main/scala/com/lookout/borderpatrol/package.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/package.scala
@@ -56,8 +56,9 @@ package object borderpatrol {
   }
 
   object errors {
-    abstract class BorderError(val status: http.Status, val description: String) extends Exception
-    class InvalidRequest(description: String = "") extends BorderError(http.Status.BadRequest, description)
+    class BorderError(val status: http.Status, val description: String) extends Exception(description)
+    class NotFoundRequest(description: String = "") extends BorderError(http.Status.NotFound, description)
+    class BadRequest(description: String = "") extends BorderError(http.Status.BadRequest, description)
     class UnauthorizedRequest(description: String = "") extends BorderError(http.Status.Unauthorized, description)
     class ForbiddenRequest(description: String = "") extends BorderError(http.Status.Forbidden, description)
   }

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Encoder.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Encoder.scala
@@ -98,7 +98,7 @@ object SessionDataEncoder {
   def apply[A](f: A => Buf, g: Buf => A): SessionDataEncoder[A] = new SessionDataEncoder[A] {
     def encode(data: A): Buf = f(data)
     def decode(buf: Buf): Try[A] = Try { g(buf) } match {
-      case Failure(e) => Failure(SessionDataError(e))
+      case Failure(e) => Failure(BpSessionDataError(e))
       case s => s
     }
   }
@@ -117,7 +117,7 @@ object SessionDataEncoder {
    */
   implicit val encodeString: SessionDataEncoder[String] = SessionDataEncoder(
     data => Buf.Utf8.apply(data),
-    buf => Buf.Utf8.unapply(buf) getOrElse (throw new SessionError("Buf conversion to String failed"))
+    buf => Buf.Utf8.unapply(buf) getOrElse (throw new BpSessionError("Buf conversion to String failed"))
   )
 
   /**
@@ -133,7 +133,7 @@ object SessionDataEncoder {
    */
   implicit val encodeInt: SessionDataEncoder[Int] = SessionDataEncoder(
     data => Buf.U32BE(data),
-    buf => Buf.U32BE.unapply(buf).map(t => t._1) getOrElse (throw new SessionError("Buf conversion to Int failed"))
+    buf => Buf.U32BE.unapply(buf).map(t => t._1) getOrElse (throw new BpSessionError("Buf conversion to Int failed"))
   )
 
 }
@@ -199,7 +199,7 @@ object SecretEncoder {
 
     def decode(json: Json): Try[Secret] =
       json.jdecode[Secret].toDisjunction.fold[Try[Secret]](
-        e => Failure(SecretDecodeError(e._1)),
+        e => Failure(BpSecretDecodeError(e._1)),
         s => Success(s)
       )
 
@@ -224,7 +224,7 @@ object SecretsEncoder {
 
     def decode(json: Json): Try[Secrets] = {
       json.as[Secrets].toDisjunction.fold[Try[Secrets]](
-        e => Failure( SecretsDecodeError(e._1)),
+        e => Failure(BpSecretsDecodeError(e._1)),
         s => Success(s)
         )
     }

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Errors.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Errors.scala
@@ -1,30 +1,28 @@
 package com.lookout.borderpatrol.sessionx
 
-class SessionError(val message: String, cause: Throwable) extends Exception(message, cause) {
-  // scalastyle:off null
-  def this(message: String) = this(message, null)
-}
+// scalastyle:off null
+class BpSessionError(val message: String) extends Exception(s"BPSESSION: $message", null)
 
-case class SignedIdError(error: String)
-    extends SessionError(s"An error occurred reading SignedId: $error")
+case class BpSignedIdError(error: String)
+    extends BpSessionError(s"An error occurred reading SignedId: $error")
 
-case class SessionDataError(error: Throwable)
-    extends SessionError(s"An error occurred reading Session data: ${error.getMessage}")
+case class BpSessionDataError(error: Throwable)
+    extends BpSessionError(s"An error occurred reading Session data: ${error.getMessage}")
 
-case class SessionStoreError(msg: String)
-    extends SessionError(s"An error occurred interacting with the session store: $msg")
+case class BpSessionStoreError(msg: String)
+    extends BpSessionError(s"An error occurred interacting with the session store: $msg")
 
-case class SecretDecodeError(msg: String)
-    extends SessionError(s"An error decoding a Secret occurred: $msg")
+case class BpSecretDecodeError(msg: String)
+    extends BpSessionError(s"An error decoding a Secret occurred: $msg")
 
-case class SecretsDecodeError(msg: String)
-  extends SessionError(s"An error decoding a Secrets occurred: $msg")
+case class BpSecretsDecodeError(msg: String)
+  extends BpSessionError(s"An error decoding a Secrets occurred: $msg")
 
-case class OriginalRequestNotFound(msg: String)
-  extends SessionError(s"An error occurred interacting with the session store: $msg")
+case class BpOriginalRequestNotFound(msg: String)
+  extends BpSessionError(s"An error occurred interacting with the session store: $msg")
 
-case class ConsulError(msg: String)
-  extends SessionError(s"An error occurred getting a value from Consul: $msg")
+case class BpConsulError(msg: String)
+  extends BpSessionError(s"An error occurred getting a value from Consul: $msg")
 
-case class SessionCreateUnavailable(msg: String)
-  extends SessionError(s"Session create failed: $msg")
+case class BpSessionCreateUnavailable(msg: String)
+  extends BpSessionError(s"Session create failed: $msg")

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/Session.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/Session.scala
@@ -83,12 +83,12 @@ object Session {
    * @return Session
    */
   def apply[A](data: A, tag: Tag = Untagged)(implicit store: SecretStoreApi): Future[Session[A]] =
-    if (store.current.expired) new SessionCreateUnavailable("only expired secrets available").toFutureException
+    if (store.current.expired) new BpSessionCreateUnavailable("only expired secrets available").toFutureException
     else {
       tag match {
         case AuthenticatedTag => SignedId.authenticated map (Session(_, data))
         case Untagged => SignedId.untagged map (Session(_, data))
-        case _ => new SessionError("Invalid SignedId Tag found").toFutureException
+        case _ => new BpSessionError("Invalid SignedId Tag found").toFutureException
       }
     }
 }

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/SessionStore.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/SessionStore.scala
@@ -93,7 +93,7 @@ object SessionStores {
     def update[A](session: Session[A])(implicit ev: SessionDataEncoder[A]): Future[Unit] = {
       delete(session.id)
       if (store.add(session.map(ev.encode))) Future.Unit
-      else Future.exception[Unit](new SessionStoreError(s"update failed with $session"))
+      else Future.exception[Unit](new BpSessionStoreError(s"update failed with $session"))
     }
 
     def delete(key: SignedId): Future[Unit] =

--- a/core/src/main/scala/com/lookout/borderpatrol/sessionx/SignedId.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/sessionx/SignedId.scala
@@ -113,7 +113,7 @@ object SignedId {
   private[this] def fromCookie(cooki: Option[Cookie], cookieName: String)(implicit ev: SecretStoreApi): Try[SignedId] =
     cooki match {
       case Some(cookie) => SignedId.from[Cookie](cookie)
-      case None => Failure(SignedIdError(s"no ${cookieName} cookie found"))
+      case None => Failure(BpSignedIdError(s"no ${cookieName} cookie found"))
     }
 
   def fromRequest(req: Request, cookieName: String = SignedId.sessionIdCookieName)(implicit ev: SecretStoreApi):
@@ -139,8 +139,8 @@ object SignedId {
       sig1 != sig2
 
     def validate(t: Time, sig1: Signature, sig2: Signature): Try[Unit] =
-      if (SignedId.expired(t)) Failure(new SignedIdError(s"Expired $t"))
-      else if (invalid(sig1, sig2)) Failure(new SignedIdError("Signature is invalid"))
+      if (SignedId.expired(t)) Failure(new BpSignedIdError(s"Expired $t"))
+      else if (invalid(sig1, sig2)) Failure(new BpSignedIdError("Signature is invalid"))
       else Success(())
 
     def long2Time(l: Long): Time =
@@ -156,7 +156,7 @@ object SignedId {
     implicit def bytes2Secret(bytes: IndexedSeq[Byte])(implicit store: SecretStoreApi): Try[Secret] =
       store.find(_.id == bytes) match {
         case Some(s) => Success(s)
-        case None => Failure(new SignedIdError(s"No secret with id=$bytes"))
+        case None => Failure(new BpSignedIdError(s"No secret with id=$bytes"))
       }
 
     implicit def bytes2Tuple(bytes: IndexedSeq[Byte]): Try[BytesTuple] = bytes match {
@@ -167,7 +167,7 @@ object SignedId {
         val (secretIdList, tagList) = tail2.splitAt(secretIdSize)
         Success((pl, tb, ent, secretIdList, tagList.head, sig))
       }
-      case _ => Failure(new SignedIdError("Not a session string"))
+      case _ => Failure(new BpSignedIdError("Not a session string"))
     }
 
     implicit def seq2SignedId(bytes: IndexedSeq[Byte])(implicit store: SecretStoreApi): Try[SignedId] = for {

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
@@ -7,7 +7,7 @@ import java.util.Date
 import javax.security.auth.x500.X500Principal
 import javax.xml.bind.DatatypeConverter
 
-import com.lookout.borderpatrol.{BinderBase, CommunicationError}
+import com.lookout.borderpatrol.{BinderBase, BpCommunicationError}
 import com.lookout.borderpatrol.sessionx._
 import com.lookout.borderpatrol.test.{sessionx, BorderPatrolSuite}
 import com.lookout.borderpatrol.util.Combinators.tap
@@ -298,11 +298,11 @@ class OAuth2Spec extends BorderPatrolSuite {
     val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeBadProtoManager)
 
     // Validate
-    val caught = the[CommunicationError] thrownBy {
+    val caught = the[BpCommunicationError] thrownBy {
       Await.result(output)
     }
-    caught.getMessage should startWith("An error occurred while talking to: " +
-      "http://localhost:9999/tokenUrl with java.net.ConnectException: Connection refused:")
+    caught.getMessage should include ("An error occurred while talking to: " +
+      "Failed to connect for: http://localhost:9999/tokenUrl")
   }
 
   /** this exception is thrown by codeToToken method in OAuth2CodeProtoManager */
@@ -347,11 +347,10 @@ class OAuth2Spec extends BorderPatrolSuite {
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
 
       // Validate
-      val caught = the[IdentityProviderError] thrownBy {
+      val caught = the[BpTokenParsingError] thrownBy {
         Await.result(output)
       }
-      caught.getMessage should be("Failed to parse the AadToken received from OAuth2 Server: ulm")
-      caught.status should be(Status.InternalServerError)
+      caught.getMessage should include ("Failed to parse the AadToken received from OAuth2 Server: ulm")
     } finally {
       server.close()
     }
@@ -377,10 +376,10 @@ class OAuth2Spec extends BorderPatrolSuite {
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, oauth2CodeProtoManager)
 
       // Validate
-      val caught = the[IdentityProviderError] thrownBy {
+      val caught = the[BpIdentityProviderError] thrownBy {
         Await.result(output)
       }
-      caught.getMessage should be("Failed to receive the AadToken from OAuth2 Server: ulm")
+      caught.getMessage should include ("Failed to receive the AadToken from OAuth2 Server: ulm")
       caught.status should be(Status.NotAcceptable)
     } finally {
       server.close()
@@ -415,7 +414,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val caught = the[BpTokenParsingError] thrownBy {
         Await.result(output)
       }
-      caught.getMessage should startWith("Failed to parse token with: Invalid serialized")
+      caught.getMessage should include ("Failed to parse token with: Invalid serialized")
     } finally {
       server.close()
     }
@@ -449,7 +448,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val caught = the[BpTokenParsingError] thrownBy {
         Await.result(output)
       }
-      caught.getMessage should startWith("Failed to parse token with: Invalid ")
+      caught.getMessage should include ("Failed to parse token with: Invalid ")
     } finally {
       server.close()
     }
@@ -487,7 +486,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val caught = the[BpTokenParsingError] thrownBy {
         Await.result(output)
       }
-      caught.getMessage should startWith("Failed to parse token with: Wrapping null input")
+      caught.getMessage should include ("Failed to parse token with: Wrapping null input")
     } finally {
       server.close()
     }
@@ -540,7 +539,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val caught = the[BpCertificateError] thrownBy {
         Await.result(output)
       }
-      caught.getMessage should startWith("Failed to process Certificate with: Unable to find certificate for")
+      caught.getMessage should include ("Failed to process Certificate with: Unable to find certificate for")
     } finally {
       server.close()
     }
@@ -592,7 +591,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val caught = the[BpCertificateError] thrownBy {
         Await.result(output)
       }
-      caught.getMessage should startWith("Failed to process Certificate with: The element type")
+      caught.getMessage should include ("Failed to process Certificate with: The element type")
     } finally {
       server.close()
     }
@@ -634,7 +633,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       val caught = the[BpCertificateError] thrownBy {
         Await.result(output)
       }
-      caught.getMessage should startWith("Failed to process Certificate with: Wrapping null input argument")
+      caught.getMessage should include ("Failed to process Certificate with: Wrapping null input argument")
     } finally {
       server.close()
     }
@@ -649,6 +648,6 @@ class OAuth2Spec extends BorderPatrolSuite {
     val caught = the[BpCertificateError] thrownBy {
       val output = new MockOAuth2CodeVerify().mockVerifier(pk.getPublic)
     }
-    caught.getMessage should startWith("Failed to process Certificate with: Unsupported PublicKey algorithm")
+    caught.getMessage should include ("Failed to process Certificate with: Unsupported PublicKey algorithm")
   }
 }

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
@@ -302,7 +302,7 @@ class OAuth2Spec extends BorderPatrolSuite {
       Await.result(output)
     }
     caught.getMessage should include ("An error occurred while talking to: " +
-      "Failed to connect for: http://localhost:9999/tokenUrl")
+      "Failed to connect for: 'http://localhost:9999/tokenUrl'")
   }
 
   /** this exception is thrown by codeToToken method in OAuth2CodeProtoManager */

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/EncoderSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/EncoderSpec.scala
@@ -34,7 +34,7 @@ class EncoderSpec extends BorderPatrolSuite {
     def invalid[A](input: A)(implicit ev: SecretEncoder[A]): Try[Secret] =
       ev.decode(input)
 
-    invalid[Json](Json.jNumber(1)).failure.exception should be(a[SecretDecodeError])
+    invalid[Json](Json.jNumber(1)).failure.exception should be(a[BpSecretDecodeError])
   }
 
   behavior of "SignedIdEncoder"
@@ -51,7 +51,7 @@ class EncoderSpec extends BorderPatrolSuite {
     def invalid[A](input: A)(implicit ev: SignedIdEncoder[A]): Try[SignedId] =
       ev.decode(input)
 
-    invalid[String]("forged secret session id").failure.exception should be(a[SignedIdError])
+    invalid[String]("forged secret session id").failure.exception should be(a[BpSignedIdError])
   }
 
   behavior of "SessionDataEncoder"
@@ -68,7 +68,7 @@ class EncoderSpec extends BorderPatrolSuite {
     def invalid[A](input: Buf)(implicit ev: SessionDataEncoder[A]): Try[A] =
       ev.decode(input)
 
-    invalid[http.Request](Buf.U32BE(1)).failure.exception should be(a[SessionDataError])
+    invalid[http.Request](Buf.U32BE(1)).failure.exception should be(a[BpSessionDataError])
   }
 
   behavior of "SecretsEncoder"

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SignedIdSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SignedIdSpec.scala
@@ -35,16 +35,16 @@ class SessionIdSpec extends BorderPatrolSuite {
   it should "not be derivable from string value if signed with secret not in the store" in {
     val idWithoutValidSecret = sessionid.untagged.copy(secret = secrets.invalid)
 
-    SignedId.from[String](idWithoutValidSecret.asBase64).failure.exception should be(a [SignedIdError])
+    SignedId.from[String](idWithoutValidSecret.asBase64).failure.exception should be(a [BpSignedIdError])
   }
 
   it should "not be derivable from string value if signatures don't match" in {
     val badId = sessionid.invalid
-    SignedId.from[String](badId.asBase64).failure.exception should be(a [SignedIdError])
+    SignedId.from[String](badId.asBase64).failure.exception should be(a [BpSignedIdError])
   }
 
   it should "not be derivable from an invalid string" in {
-    SignedId.from[String]("hello world!").failure.exception should be(a [SignedIdError])
+    SignedId.from[String]("hello world!").failure.exception should be(a [BpSignedIdError])
   }
 
   it should "create a tagged sessionId" in {

--- a/server/src/main/scala/com/lookout/borderpatrol/server/Config.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/Config.scala
@@ -28,16 +28,16 @@ case class ServerConfig(listeningPort: Int,
                         accessManagers: Set[Manager]) {
 
   def findIdentityManager(n: String): Manager = identityManagers.find(_.name == n)
-    .getOrElse(throw new InvalidConfigError("Failed to find IdentityManager for: " + n))
+    .getOrElse(throw new BpInvalidConfigError("Failed to find IdentityManager for: " + n))
 
   def findAccessManager(n: String): Manager = accessManagers.find(_.name == n)
-    .getOrElse(throw new InvalidConfigError("Failed to find Manager for: " + n))
+    .getOrElse(throw new BpInvalidConfigError("Failed to find Manager for: " + n))
 
   def findLoginManager(n: String): LoginManager = loginManagers.find(_.name == n)
-    .getOrElse(throw new InvalidConfigError("Failed to find LoginManager for: " + n))
+    .getOrElse(throw new BpInvalidConfigError("Failed to find LoginManager for: " + n))
 
   def findServiceIdentifier(n: String): ServiceIdentifier = serviceIdentifiers.find(_.name == n)
-    .getOrElse(throw new InvalidConfigError("Failed to find ServiceIdentifier for: " + n))
+    .getOrElse(throw new BpInvalidConfigError("Failed to find ServiceIdentifier for: " + n))
 }
 
 case class StatsdExporterConfig(host: String, durationInSec: Int, prefix: String)
@@ -375,13 +375,13 @@ object Config {
       /** Validate the parsed config */
       case Xor.Right(cfg) => validate(cfg) match {
         case s if s.isEmpty => cfg
-        case s => throw ConfigError(s.mkString("\n\t", "\n\t", "\n"))
+        case s => throw BpConfigError(s.mkString("\n\t", "\n\t", "\n"))
       }
       case Xor.Left(err) => {
         val fields = "CursorOpDownField\\(([A-Za-z]+)\\)".r.findAllIn(err.getMessage).matchData.map(
           m => m.group(1)).mkString(",")
         val reason = err.getMessage.reverse.dropWhile(_ != ':').reverse
-        throw ConfigError(s"${reason}failed to decode following field(s): $fields")
+        throw BpConfigError(s"${reason}failed to decode following field(s): $fields")
       }
     }
   }

--- a/server/src/main/scala/com/lookout/borderpatrol/server/Errors.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/Errors.scala
@@ -1,12 +1,12 @@
 package com.lookout.borderpatrol.server
 
 // scalastyle:off null
-case class ConfigError(message: String)
-  extends Exception(s"An error occurred while reading BorderPatrol Configuration: ${message}", null)
+case class BpConfigError(message: String)
+  extends Exception(s"BPCONFIG: An error occurred while reading BorderPatrol Configuration: ${message}", null)
 
-case class DuplicateConfigError(key: String, field: String)
+case class BpDuplicateConfigError(key: String, field: String)
   extends Exception("An error occurred while reading BorderPatrol Configuration: " +
     s"Duplicate entries for key(s) (${key}) - are found in the field: ${field}")
 
-case class InvalidConfigError(message: String)
+case class BpInvalidConfigError(message: String)
   extends Exception(message, null)

--- a/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
@@ -114,16 +114,16 @@ class ConfigSpec extends BorderPatrolSuite {
     serverConfig.findIdentityManager("keymaster") should be(keymasterIdManager)
     serverConfig.findAccessManager("keymaster") should be(keymasterAccessManager)
     serverConfig.findServiceIdentifier("one") should be(one)
-    the[InvalidConfigError] thrownBy {
+    the[BpInvalidConfigError] thrownBy {
       serverConfig.findLoginManager("foo")
     }
-    the[InvalidConfigError] thrownBy {
+    the[BpInvalidConfigError] thrownBy {
       serverConfig.findIdentityManager("foo")
     }
-    the[InvalidConfigError] thrownBy {
+    the[BpInvalidConfigError] thrownBy {
       serverConfig.findAccessManager("foo")
     }
-    the[InvalidConfigError] thrownBy {
+    the[BpInvalidConfigError] thrownBy {
       serverConfig.findServiceIdentifier("foo")
     }
   }
@@ -141,13 +141,13 @@ class ConfigSpec extends BorderPatrolSuite {
     val invalidContents = """[{"name":"one","path": {"str" :"customer1"},"subdomain":"customer1","login":"/login"}]"""
     val tempInvalidFile = File.makeTemp("ServerConfigSpecInvalid", ".tmp")
     tempInvalidFile.writeAll(invalidContents)
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempInvalidFile.toCanonical.toString)
     }
     caught.getMessage should include ("failed to decode following field(s): listeningPort")
   }
 
-  it should "raise a ConfigError exception due to lack of listeningPort config" in {
+  it should "raise a BpConfigError exception due to lack of listeningPort config" in {
     val partialContents = Json.fromFields(Seq(
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
@@ -161,13 +161,13 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include ("failed to decode following field(s): listeningPort")
   }
 
-  it should "raise a ConfigError exception due to lack of Secret Store config" in {
+  it should "raise a BpConfigError exception due to lack of Secret Store config" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
@@ -181,13 +181,13 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include ("failed to decode following field(s): secretStore")
   }
 
-  it should "raise a ConfigError exception due to invalid of Secret Store config" in {
+  it should "raise a BpConfigError exception due to invalid of Secret Store config" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", Json.obj(("type", Json.string("woof")))),
@@ -202,13 +202,13 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include ("Invalid secretStore:failed to decode following field(s): secretStore")
   }
 
-  it should "raise a ConfigError exception due to lack of Session Store config" in {
+  it should "raise a BpConfigError exception due to lack of Session Store config" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", consulSecretStore.asInstanceOf[SecretStoreApi].asJson),
@@ -222,13 +222,13 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include ("failed to decode following field(s): sessionStore")
   }
 
-  it should "raise a ConfigError exception due to invalid Session Store config" in {
+  it should "raise a BpConfigError exception due to invalid Session Store config" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", consulSecretStore.asInstanceOf[SecretStoreApi].asJson),
@@ -243,13 +243,13 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include ("Invalid sessionStore:failed to decode following field(s): sessionStore")
   }
 
-  it should "raise a ConfigError exception due to lack of Statsd Reporter config" in {
+  it should "raise a BpConfigError exception due to lack of Statsd Reporter config" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
@@ -263,13 +263,13 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include ("failed to decode following field(s): statsdReporter")
   }
 
-  it should "raise a ConfigError exception due to lack of CustomerIdentifier config" in {
+  it should "raise a BpConfigError exception due to lack of CustomerIdentifier config" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
@@ -283,13 +283,13 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include ("failed to decode following field(s): customerIdentifiers")
   }
 
-  it should "raise a ConfigError exception due to missing LoginManager in CustomerIdentifier config" in {
+  it should "raise a BpConfigError exception due to missing LoginManager in CustomerIdentifier config" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
@@ -307,14 +307,14 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include (
       "LoginManager \"bad\" not found:failed to decode following field(s): customerIdentifiers")
   }
 
-  it should "raise a ConfigError exception due to missing ServiceIdentifier in CustomerIdentifier config" in {
+  it should "raise a BpConfigError exception due to missing ServiceIdentifier in CustomerIdentifier config" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
@@ -332,14 +332,14 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include (
       "ServiceIdentifier \"bad\" not found:failed to decode following field(s): customerIdentifiers")
   }
 
-  it should "raise a ConfigError exception due to lack of ServiceIdentifier config" in {
+  it should "raise a BpConfigError exception due to lack of ServiceIdentifier config" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
@@ -353,13 +353,13 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include ("failed to decode following field(s): serviceIdentifiers")
   }
 
-  it should "raise a ConfigError exception if identityManager that is used in LoginManager is missing" in {
+  it should "raise a BpConfigError exception if identityManager that is used in LoginManager is missing" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
@@ -374,14 +374,14 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include (
       "IdentityManager \"keymaster\" not found:failed to decode following field(s): loginManagers")
   }
 
-  it should "raise a ConfigError exception if duplicate are configured in idManagers config" in {
+  it should "raise a BpConfigError exception if duplicate are configured in idManagers config" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
@@ -397,13 +397,13 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include ("Duplicate entries for key (name) are found in the field: identityManagers")
   }
 
-  it should "raise a ConfigError exception if accessManager that is used in LoginManager is missing" in {
+  it should "raise a BpConfigError exception if accessManager that is used in LoginManager is missing" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
@@ -418,14 +418,14 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include (
       "AccessManager \"keymaster\" not found:failed to decode following field(s): loginManagers")
   }
 
-  it should "raise a ConfigError exception if duplicates are configured in accessManagers config" in {
+  it should "raise a BpConfigError exception if duplicates are configured in accessManagers config" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
@@ -441,13 +441,13 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include ("Duplicate entries for key (name) are found in the field: accessManagers")
   }
 
-  it should "raise a ConfigError exception if duplicates are configured in loginManagers config" in {
+  it should "raise a BpConfigError exception if duplicates are configured in loginManagers config" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
@@ -464,13 +464,13 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include ("Duplicate entries for key (name) are found in the field: loginManagers")
   }
 
-  it should "raise a ConfigError exception if duplicate paths are configured in serviceIdentifiers config" in {
+  it should "raise a BpConfigError exception if duplicate paths are configured in serviceIdentifiers config" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
@@ -485,14 +485,14 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include (
       "Duplicate entries for key (path) are found in the field: serviceIdentifiers")
   }
 
-  it should "raise a ConfigError exception if duplicate subdomains are configured in customerIdentifiers config" in {
+  it should "raise a BpConfigError exception if duplicate subdomains are configured in customerIdentifiers config" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
@@ -507,14 +507,14 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include (
       "Duplicate entries for key (subdomain) are found in the field: customerIdentifiers")
   }
 
-  it should "raise a ConfigError exception when it catches multiple errors in the config" in {
+  it should "raise a BpConfigError exception when it catches multiple errors in the config" in {
     val partialContents = Json.fromFields(Seq(
       ("listeningPort", bpPort.asJson),
       ("secretStore", defaultSecretStore.asInstanceOf[SecretStoreApi].asJson),
@@ -529,7 +529,7 @@ class ConfigSpec extends BorderPatrolSuite {
     val tempFile = File.makeTemp("ServerConfigTest", ".tmp")
     tempFile.writeAll(partialContents.toString)
 
-    val caught = the [ConfigError] thrownBy {
+    val caught = the [BpConfigError] thrownBy {
       readServerConfig(tempFile.toCanonical.toString)
     }
     caught.getMessage should include (


### PR DESCRIPTION
- Added prefix "Bp" to all the BP errors/exceptions
- Throw Bp exceptions for all the error responses generated by BP2
- Convert exceptions to error responses in the ExceptionFilter
- If request is exepcting an application/json response, then return
  a response with custom response (e.g. contains a redirect_url)