### PR TITLE
Add labels for connection metrics and perf fixes

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
@@ -10,7 +10,7 @@ import com.lookout.borderpatrol.auth._
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.{Filter, Service}
 import com.twitter.finagle.http._
-import com.twitter.logging.{Logger, Level}
+import com.twitter.logging.Logger
 import com.twitter.util.Future
 
 
@@ -190,11 +190,10 @@ object Keymaster {
     /**
      * Fetch a valid ServiceToken, will return a ServiceToken otherwise a Future.exception
      */
-    def apply(req: AccessRequest[Tokens]): Future[AccessResponse[ServiceToken]] =
+    def apply(req: AccessRequest[Tokens]): Future[AccessResponse[ServiceToken]] = {
       //  Check if ServiceToken is already available for Service
       req.identity.id.service(req.serviceId.name).fold[Future[ServiceToken]]({
         statRequestSends.incr()
-
         //  Fetch ServiceToken from the Keymaster
         binder(BindRequest(req.customerId.loginManager.accessManager, api(req))).flatMap(res => res.status match {
           //  Parse for Tokens if Status.Ok
@@ -224,6 +223,7 @@ object Keymaster {
         statCacheHits.incr()
         Future.value(t)
       }).map(t => KeymasterAccessRes(Access(t)))
+    }
   }
 
   /**

--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
@@ -73,12 +73,12 @@ object Keymaster {
         case Status.Forbidden => {
           statResponseDenied.incr
           Future.exception(BpIdentityProviderError(Status.Forbidden,
-            s"IdentityProvider denied user: ${req.credential.uniqueId} with status: ${res.status}"))
+            s"IdentityProvider denied user: '${req.credential.uniqueId}' with status: ${res.status}"))
         }
         case _ => {
           statResponseFailed.incr
           Future.exception(BpIdentityProviderError(Status.InternalServerError,
-            s"IdentityProvider denied user: ${req.credential.uniqueId} with status: ${res.status}"))
+            s"IdentityProvider denied user: '${req.credential.uniqueId}' with status: ${res.status}"))
         }
       })
     }
@@ -151,7 +151,7 @@ object Keymaster {
           _ <- store.delete(req.sessionId)
         } yield {
           statSessionAuthenticated.incr
-          throw BpRedirectError(Status.Ok, originReq.uri, session.id,
+          throw BpRedirectError(Status.Ok, originReq.uri, Some(session.id),
             s"Session: ${req.sessionId.toLogIdString}} is authenticated, " +
               s"allocated new Session: ${session.id.toLogIdString} and redirecting to " +
               s"location: ${originReq.uri}")
@@ -216,7 +216,7 @@ object Keymaster {
           case _ => {
             statsResponseFailed.incr()
             Future.exception(BpAccessIssuerError(Status.InternalServerError,
-              s"AccessIssuer denied access to service: ${req.serviceId.name} with status: ${res.status}"))
+              s"AccessIssuer denied access to service: '${req.serviceId.name}' with status: ${res.status}"))
           }
         })
       })(t => {

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/keymaster/KeymasterSpec.scala
@@ -97,7 +97,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     val caught = the [BpIdentityProviderError] thrownBy {
       Await.result(output)
     }
-    caught.getMessage should include ("IdentityProvider denied user: foo")
+    caught.getMessage should include ("IdentityProvider denied user: 'foo'")
     caught.status should be (Status.Forbidden)
   }
 
@@ -121,7 +121,7 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     val caught = the [BpIdentityProviderError] thrownBy {
       Await.result(output)
     }
-    caught.getMessage should include ("IdentityProvider denied user: foo")
+    caught.getMessage should include ("IdentityProvider denied user: 'foo'")
     caught.status should be (Status.InternalServerError)
   }
 
@@ -271,8 +271,8 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     // Validate
     caught.status should be(Status.Ok)
     caught.location should be equals ("/dang")
-    caught.sessionId should not be sessionId
-    val tokensz = getTokensFromSessionId(caught.sessionId)
+    caught.sessionIdOpt should not be (Some(sessionId))
+    val tokensz = getTokensFromSessionId(caught.sessionIdOpt.get)
     Await.result(tokensz) should be(tokens)
   }
 
@@ -308,8 +308,8 @@ class KeymasterSpec extends BorderPatrolSuite with MockitoSugar {
     // Validate
     caught.status should be(Status.Ok)
     caught.location should be equals ("/umb")
-    caught.sessionId should not be sessionId
-    val tokensz = getTokensFromSessionId(caught.sessionId)
+    caught.sessionIdOpt should not be (Some(sessionId))
+    val tokensz = getTokensFromSessionId(caught.sessionIdOpt.get)
     Await.result(tokensz) should be(tokens)
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.1.15-SNAPSHOT"
+lazy val Version = "0.1.16-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/HealthCheck.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/HealthCheck.scala
@@ -32,7 +32,7 @@ object HealthCheck {
   /** BorderPatrol health check on a URL */
   case class UrlHealthCheck(name: String, url: URL) extends HealthCheck {
     def check(): Future[HealthCheckStatus] =
-      BinderBase.connect(url.toString, Set(url), Request()).map(rep => rep.status match {
+      BinderBase.connect(s"${getClass.getSimpleName}.$name", Set(url), Request()).map(rep => rep.status match {
         case Status.Ok => HealthCheckStatus.healthy
         case _ => HealthCheckStatus.unhealthy(rep.status, rep.status.reason.asJson)
       })

--- a/core/src/main/scala/com/lookout/borderpatrol/HealthCheck.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/HealthCheck.scala
@@ -88,5 +88,5 @@ class HealthCheckRegistry {
     healthChecks.putIfAbsent(healthCheck.name, healthCheck)
 
   def collectHealthCheckResults(): Future[Map[String, HealthCheckStatus]] =
-    Future.collect((healthChecks map { e => (e._1, e._2.execute())}).toMap)
+    Future.collect((healthChecks.map(hc => (hc._1, hc._2.execute()))).toMap)
 }

--- a/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
@@ -39,6 +39,7 @@ trait ProtoManager {
 /**
  * Internal authentication, that merely redirects user to internal service that does the authentication
  *
+ * @param name name of the proto manager
  * @param loginConfirm path intercepted by bordetpatrol and internal authentication service posts
  *                     the authentication response on this path
  * @param authorizePath path of the internal authentication service where client is redirected
@@ -52,6 +53,7 @@ case class InternalAuthProtoManager(name: String, loginConfirm: Path, authorizeP
 /**
  * OAuth code framework, that redirects user to OAuth2 server.
  *
+ * @param name name of the proto manager
  * @param loginConfirm path intercepted by borderpatrol and OAuth2 server posts the oAuth2 code on this path
  * @param authorizeUrl URL of the OAuth2 service where client is redirected for authenticaiton
  * @param tokenUrl URL of the OAuth2 server to convert OAuth2 code to OAuth2 token

--- a/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
@@ -30,6 +30,7 @@ case class LoginManager(name: String, identityManager: Manager, accessManager: M
  * ProtoManager defines parameters specific to the protocol
  */
 trait ProtoManager {
+  val name: String
   val loginConfirm: Path
   val loggedOutUrl: Option[URL]
   def redirectLocation(host: Option[String]): String
@@ -43,7 +44,7 @@ trait ProtoManager {
  * @param authorizePath path of the internal authentication service where client is redirected
  * @param loggedOutUrl A Url where user is redirected after the Logout
  */
-case class InternalAuthProtoManager(loginConfirm: Path, authorizePath: Path, loggedOutUrl: Option[URL])
+case class InternalAuthProtoManager(name: String, loginConfirm: Path, authorizePath: Path, loggedOutUrl: Option[URL])
     extends ProtoManager {
   def redirectLocation(host: Option[String]): String = authorizePath.toString
 }
@@ -59,8 +60,9 @@ case class InternalAuthProtoManager(loginConfirm: Path, authorizePath: Path, log
  * @param clientId Id used for communicating with OAuth2 server
  * @param clientSecret Secret used for communicating with OAuth2 server
  */
-case class OAuth2CodeProtoManager(loginConfirm: Path, authorizeUrl: URL, tokenUrl: URL, certificateUrl: URL,
-                                  loggedOutUrl: Option[URL], clientId: String, clientSecret: String)
+case class OAuth2CodeProtoManager(name: String, loginConfirm: Path, authorizeUrl: URL, tokenUrl: URL,
+                                  certificateUrl: URL, loggedOutUrl: Option[URL], clientId: String,
+                                  clientSecret: String)
     extends ProtoManager{
   private[this] val log = Logger.get(getClass.getPackage.getName)
 
@@ -79,6 +81,6 @@ case class OAuth2CodeProtoManager(loginConfirm: Path, authorizeUrl: URL, tokenUr
         .drop(1) /* Drop '?' */
     })
     log.debug(s"Sending: ${request} to location: ${tokenUrl}")
-    BinderBase.connect(tokenUrl.toString, Set(tokenUrl), request)
+    BinderBase.connect(s"${name}.tokenUrl", Set(tokenUrl), request)
   }
 }

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/Errors.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/Errors.scala
@@ -38,7 +38,8 @@ case class BpAccessIssuerError(status: Status, msg: String) extends BpAuthError(
 /**
  * This exception stores the response code
  */
-case class BpRedirectError(status: Status, location: String, sessionId: SignedId, msg: String) extends BpAuthError(msg)
+case class BpRedirectError(status: Status, location: String, sessionIdOpt: Option[SignedId], msg: String)
+    extends BpAuthError(msg)
 
 /**
  * This exception stores the response code

--- a/core/src/test/scala/com/lookout/borderpatrol/test/HealthCheckSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/HealthCheckSpec.scala
@@ -92,9 +92,9 @@ class HealthCheckSpec extends BorderPatrolSuite {
 
   it should "collect output from all HealthChecks" in {
     val server = com.twitter.finagle.Http.serve(
-      "localhost:5678", mkTestService[Request, Response] { _ => Response(Status.Ok).toFuture})
+      "localhost:5679", mkTestService[Request, Response] { _ => Response(Status.Ok).toFuture})
     try {
-      val goodUrlHealthCheck = UrlHealthCheck("goodUrlHealthCheck", new URL("http://localhost:5678"))
+      val goodUrlHealthCheck = UrlHealthCheck("goodUrlHealthCheck", new URL("http://localhost:5679"))
       val badUrlHealthCheck = UrlHealthCheck("badUrlHealthCheck", new URL("http://localhost:999"))
       val registry = new HealthCheckRegistry()
       registry.register(goodUrlHealthCheck)

--- a/core/src/test/scala/com/lookout/borderpatrol/test/HealthCheckSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/HealthCheckSpec.scala
@@ -107,7 +107,7 @@ class HealthCheckSpec extends BorderPatrolSuite {
       Await.result(output).get("goodUrlHealthCheck").get.status should be(Status.Ok)
       Await.result(output).get("badUrlHealthCheck").get.status should be(Status.InternalServerError)
       Await.result(output).asJson.toString() should include(
-        "An error occurred while talking to: Failed to connect for: 'http://localhost:999'")
+        "An error occurred while talking to: Failed to connect for: 'UrlHealthCheck.badUrlHealthCheck'")
 
     } finally {
       server.close()

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
@@ -208,8 +208,8 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     // Validate
     caught.status should be(Status.Unauthorized)
     caught.location should be equals ("/dang")
-    caught.sessionId should not be sessionId
-    val reqZ = getRequestFromSessionId(caught.sessionId)
+    caught.sessionIdOpt should not be (Some(sessionId))
+    val reqZ = getRequestFromSessionId(caught.sessionIdOpt.get)
     Await.result(reqZ).uri should be(request.uri)
   }
 
@@ -364,7 +364,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
 
   it should "succeed and convert the BpRedirectError exception into error Response" in {
     val testService = mkTestService[Request, Response] { req =>
-      Future.exception(BpRedirectError(Status.Unauthorized, "/location", sessionid.untagged,
+      Future.exception(BpRedirectError(Status.Unauthorized, "/location", Some(sessionid.untagged),
         "Some identity provider error"))
     }
 
@@ -379,7 +379,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
 
   it should "succeed and convert the BpRedirectError exception into error Response with json body" in {
     val testService = mkTestService[Request, Response] { req =>
-      Future.exception(BpRedirectError(Status.Unauthorized, "/location", sessionid.untagged,
+      Future.exception(BpRedirectError(Status.Unauthorized, "/location", Some(sessionid.untagged),
         "Some identity provider error"))
     }
 
@@ -517,7 +517,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     // Validate
     caught.status should be(Status.Unauthorized)
     caught.location should be (internalProtoManager.authorizePath.toString)
-    caught.sessionId should be (sessionId)
+    caught.sessionIdOpt should be (Some(sessionId))
   }
 
   it should "redirect the request w/ unauth SessionId for protected service to login page for OAuth2" in {
@@ -543,7 +543,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     // Validate
     caught.status should be(Status.Unauthorized)
     caught.location should startWith (oauth2CodeProtoManager.authorizeUrl.toString)
-    caught.sessionId should be (sessionId)
+    caught.sessionIdOpt should be (Some(sessionId))
   }
 
   it should "redirect the request w/ unauth SessionId to unknown path to login page" in {
@@ -569,7 +569,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
     // Validate
     caught.status should be(Status.Unauthorized)
     caught.location should be (internalProtoManager.authorizePath.toString)
-    caught.sessionId should be (sessionId)
+    caught.sessionIdOpt should be (Some(sessionId))
   }
 
   it should "throw an BpIdentityProviderError if it fails to find IdentityProvider service chain" in {

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/OAuth2Spec.scala
@@ -301,8 +301,8 @@ class OAuth2Spec extends BorderPatrolSuite {
     val caught = the[BpCommunicationError] thrownBy {
       Await.result(output)
     }
-    caught.getMessage should include ("An error occurred while talking to: " +
-      "Failed to connect for: 'http://localhost:9999/tokenUrl'")
+    caught.getMessage should include (
+      "An error occurred while talking to: Failed to connect for: 'rlmProtoManager.tokenUrl'")
   }
 
   /** this exception is thrown by codeToToken method in OAuth2CodeProtoManager */

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
@@ -62,10 +62,10 @@ object helpers {
   //  Managers
   val keymasterIdManager = Manager("keymaster", Path("/identityProvider"), urls)
   val keymasterAccessManager = Manager("keymaster", Path("/accessIssuer"), urls)
-  val internalProtoManager = InternalAuthProtoManager(Path("/loginConfirm"), Path("/check"), None)
+  val internalProtoManager = InternalAuthProtoManager("checkpointProtoManager", Path("/loginConfirm"), Path("/check"), None)
   val checkpointLoginManager = LoginManager("checkpoint", keymasterIdManager, keymasterAccessManager,
     internalProtoManager)
-  val oauth2CodeProtoManager = OAuth2CodeProtoManager(Path("/signin"),
+  val oauth2CodeProtoManager = OAuth2CodeProtoManager("ulmProtoManager", Path("/signin"),
     new URL("http://example.com/authorizeUrl"),
     new URL("http://localhost:4567/tokenUrl"),
     new URL("http://localhost:4567/certificateUrl"),
@@ -73,7 +73,7 @@ object helpers {
     "clientId", "clientSecret")
   val umbrellaLoginManager = LoginManager("ulm", keymasterIdManager, keymasterAccessManager,
     oauth2CodeProtoManager)
-  val oauth2CodeBadProtoManager = OAuth2CodeProtoManager(Path("/signblew"),
+  val oauth2CodeBadProtoManager = OAuth2CodeProtoManager("rlmProtoManager", Path("/signblew"),
     new URL("http://localhost:9999/authorizeUrl"),
     new URL("http://localhost:9999/tokenUrl"),
     new URL("http://localhost:9999/certificateUrl"),

--- a/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
@@ -13,7 +13,6 @@ import scala.util.{Failure, Success, Try}
 
 object BorderPatrolApp extends TwitterServer with Config {
   import service._
-  import MockService._
   import Config._
 
   premain {

--- a/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
@@ -47,7 +47,7 @@ object MockService {
   val mockKeymasterIdentityService = new Service[Request, Response] {
 
     val userMap: Map[String, String] = Map(
-      ("test@example.com" -> "testthis")
+      ("test1@example.com" -> "password1")
     )
 
     def apply(request: Request): Future[Response] = {

--- a/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
@@ -47,7 +47,7 @@ object MockService {
   val mockKeymasterIdentityService = new Service[Request, Response] {
 
     val userMap: Map[String, String] = Map(
-      ("test1@example.com" -> "password1")
+      ("test@example.com" -> "testthis")
     )
 
     def apply(request: Request): Future[Response] = {
@@ -116,7 +116,8 @@ object MockService {
       }).toFuture
   }
 
-  def getMockRoutingService(implicit config: ServerConfig): Service[Request, Response] = {
+  def getMockRoutingService(implicit config: ServerConfig, statsReceiver: StatsReceiver):
+      Service[Request, Response] = {
     val checkpoint = config.findServiceIdentifier("checkpoint")
     val keymasterIdManager = config.findIdentityManager("keymaster")
     val keymasterAccessManager = config.findAccessManager("keymaster")
@@ -128,7 +129,7 @@ object MockService {
       case keymasterAccessManager.path => mockKeymasterAccessIssuerService
       case keymasterIdManager.path => mockKeymasterIdentityService
       case path if path.startsWith(checkpoint.path) => mockCheckpointService
-      case path if path.startsWith(logout.rewritePath.fold(path)(p => p)) =>
+      case path if path.startsWith(logout.rewritePath.getOrElse(path)) =>
         ExceptionFilter() andThen /* Convert exceptions to responses */
         CustomerIdFilter(serviceMatcher) andThen /* Validate that its our service */
         LogoutService(config.sessionStore)

--- a/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
@@ -35,13 +35,63 @@ import com.lookout.borderpatrol.util.Combinators._
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.io.Buf
 import com.twitter.finagle.http.{Method, Request, Response, Status}
-import com.twitter.finagle.http.service.{NotFoundService, RoutingService}
+import com.twitter.finagle.http.service.RoutingService
 import com.twitter.finagle.Service
 import com.twitter.util.Future
 import io.finch.response.ResponseBuilder
 
 
-object MockService {
+object service {
+  /**
+   * Get IdentityProvider map of name -> Service chain
+   *
+   * As of now, we only support `keymaster` as an Identity Provider
+   */
+  def identityProviderChainMap(sessionStore: SessionStore)(
+    implicit store: SecretStoreApi, statsReceiver: StatsReceiver):
+  Map[String, Service[BorderRequest, Response]] =
+    Map("keymaster" -> keymasterIdentityProviderChain(sessionStore))
+
+  /**
+   * Get AccessIssuer map of name -> Service chain
+   *
+   * As of now, we only support `keymaster` as an Access Issuer
+   */
+  def accessIssuerChainMap(sessionStore: SessionStore)(
+    implicit store: SecretStoreApi, statsReceiver: StatsReceiver):
+  Map[String, Service[BorderRequest, Response]] =
+    Map("keymaster" -> keymasterAccessIssuerChain(sessionStore))
+
+  /**
+   * The sole entry point for all service chains
+   */
+  def MainServiceChain(implicit config: ServerConfig, statsReceiver: StatsReceiver, registry: HealthCheckRegistry,
+                       secretStore: SecretStoreApi):
+      Service[Request, Response] = {
+    val serviceMatcher = ServiceMatcher(config.customerIdentifiers, config.serviceIdentifiers)
+    val notFoundService = Service.mk[SessionIdRequest, Response] { req => Response(Status.NotFound).toFuture }
+
+    RoutingService.byPath {
+      case "/health" =>
+        HealthCheckService(registry)
+
+      case _ =>
+        /* Convert exceptions to responses */
+        ExceptionFilter() andThen
+          /* Validate that its our service */
+          CustomerIdFilter(serviceMatcher) andThen
+          /* Get or allocate Session/SignedId */
+          SessionIdFilter(serviceMatcher, config.sessionStore) andThen
+          /* If unauthenticated, send it to Identity Provider or login page */
+          SendToIdentityProvider(identityProviderChainMap(config.sessionStore), config.sessionStore) andThen
+          /* If authenticated and protected service, send it via Access Issuer chain */
+          SendToAccessIssuer(accessIssuerChainMap(config.sessionStore)) andThen
+          /* Authenticated or not, send it to unprotected service, if its destined to that */
+          SendToUnprotectedService(ServiceIdentifierBinder) andThen
+          /* Not found */
+          notFoundService
+    }
+  }
 
   //  Mock Keymaster identityManager
   val mockKeymasterIdentityService = new Service[Request, Response] {
@@ -108,16 +158,17 @@ object MockService {
       tap(Response(Status.Ok))(res => {
         res.contentString =
           s"""
-          |<html><body>
-          |<h1>Welcome to Service @(${request.path})</h1>
-          |</body></html>
+             |<html><body>
+             |<h1>Welcome to Service @(${request.path})</h1>
+                                                        |</body></html>
           """.stripMargin
         res.contentType = "text/html"
       }).toFuture
   }
 
+  // Mock Routing service
   def getMockRoutingService(implicit config: ServerConfig, statsReceiver: StatsReceiver):
-      Service[Request, Response] = {
+  Service[Request, Response] = {
     val checkpoint = config.findServiceIdentifier("checkpoint")
     val keymasterIdManager = config.findIdentityManager("keymaster")
     val keymasterAccessManager = config.findAccessManager("keymaster")
@@ -131,62 +182,9 @@ object MockService {
       case path if path.startsWith(checkpoint.path) => mockCheckpointService
       case path if path.startsWith(logout.rewritePath.getOrElse(path)) =>
         ExceptionFilter() andThen /* Convert exceptions to responses */
-        CustomerIdFilter(serviceMatcher) andThen /* Validate that its our service */
-        LogoutService(config.sessionStore)
+          CustomerIdFilter(serviceMatcher) andThen /* Validate that its our service */
+          LogoutService(config.sessionStore)
       case _ => mockUpstreamService
-    }
-  }
-}
-
-object service {
-  /**
-   * Get IdentityProvider map of name -> Service chain
-   *
-   * As of now, we only support `keymaster` as an Identity Provider
-   */
-  def identityProviderChainMap(sessionStore: SessionStore)(
-    implicit store: SecretStoreApi, statsReceiver: StatsReceiver):
-  Map[String, Service[BorderRequest, Response]] =
-    Map("keymaster" -> keymasterIdentityProviderChain(sessionStore))
-
-  /**
-   * Get AccessIssuer map of name -> Service chain
-   *
-   * As of now, we only support `keymaster` as an Access Issuer
-   */
-  def accessIssuerChainMap(sessionStore: SessionStore)(
-    implicit store: SecretStoreApi, statsReceiver: StatsReceiver):
-  Map[String, Service[BorderRequest, Response]] =
-    Map("keymaster" -> keymasterAccessIssuerChain(sessionStore))
-
-  /**
-   * The sole entry point for all service chains
-   */
-  def MainServiceChain(implicit config: ServerConfig, statsReceiver: StatsReceiver, registry: HealthCheckRegistry,
-                       secretStore: SecretStoreApi):
-      Service[Request, Response] = {
-    val serviceMatcher = ServiceMatcher(config.customerIdentifiers, config.serviceIdentifiers)
-    val notFoundService = Service.mk[SessionIdRequest, Response] { req => Response(Status.NotFound).toFuture }
-
-    RoutingService.byPath {
-      case "/health" =>
-        HealthCheckService(registry)
-
-      case _ =>
-        /* Convert exceptions to responses */
-        ExceptionFilter() andThen
-          /* Validate that its our service */
-          CustomerIdFilter(serviceMatcher) andThen
-          /* Get or allocate Session/SignedId */
-          SessionIdFilter(serviceMatcher, config.sessionStore) andThen
-          /* If unauthenticated, send it to Identity Provider or login page */
-          SendToIdentityProvider(identityProviderChainMap(config.sessionStore), config.sessionStore) andThen
-          /* If authenticated and protected service, send it via Access Issuer chain */
-          SendToAccessIssuer(accessIssuerChainMap(config.sessionStore)) andThen
-          /* Authenticated or not, send it to unprotected service, if its destined to that */
-          SendToUnprotectedService(ServiceIdentifierBinder) andThen
-          /* Not found */
-          notFoundService
     }
   }
 }

--- a/server/src/main/scala/com/lookout/borderpatrol/server/StatsdExporter.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/StatsdExporter.scala
@@ -1,6 +1,7 @@
 package com.lookout.borderpatrol.server
 
-import java.net.InetAddress
+import java.io.{Writer, BufferedWriter, OutputStreamWriter, ByteArrayOutputStream}
+import java.net.{StandardProtocolFamily, SocketOption, StandardSocketOptions, InetAddress}
 import java.nio.ByteBuffer
 import java.nio.channels.DatagramChannel
 
@@ -19,15 +20,18 @@ case class StatsdExporter(registry: Metrics, timer: Timer, prefix: String = "", 
                           hostAndPort: String) {
   private[this] val log = Logger.get(getClass.getPackage.getName)
   private[this] val addr = InetSocketAddressUtil.parseHosts(hostAndPort).head
-  private[this] val channel = DatagramChannel.open()
+  private[this] val channel = DatagramChannel.open(StandardProtocolFamily.INET)
+    .setOption(StandardSocketOptions.SO_SNDBUF.asInstanceOf[SocketOption[Any]], 64000)
+  private[this] val outputData = new ByteArrayOutputStream()
 
   // Schedule exporter
   timer.schedule(duration)(report)
 
   // Format helpers
-  private[this] def format(names: Seq[String], value: String, term: String): String = {
+  private[this] def format(writer: Writer, names: Seq[String], value: String, term: String): Unit = {
     val n = names.filter(_.nonEmpty).mkString(".").replaceAll("/", ".").replaceAll(":", "_")
-    s"${n}:$value|$term"
+    writer.write(s"${n}:$value|$term\n")
+    writer.flush()
   }
 
   private[this] def format(n: Long): String = n.toString
@@ -48,13 +52,16 @@ case class StatsdExporter(registry: Metrics, timer: Timer, prefix: String = "", 
   private[this] def byteBuf(buf: Buf): ByteBuffer =
     Buf.ByteBuffer.Owned.extract(buf)
 
-  private[this] def send(str: String): Unit =
+  private[this] def send(str: String): Unit = {
     Try(channel.send(byteBuf(buf(str)), addr)).recover {
-      case e => log.info(s"Failed to send stats to: $hostAndPort with: ${e.getMessage}")
+      case e => log.warning(s"Failed to send stats to: $hostAndPort, size: ${str.size} with: ${e.getMessage}")
     }
+  }
 
   // Report
   def report(): Unit = {
+    outputData.reset()
+    val writer = new BufferedWriter(new OutputStreamWriter(outputData))
     val gauges = try registry.sampleGauges().asScala catch {
       case NonFatal(e) =>
         // because gauges run arbitrary user code, we want to protect ourselves here.
@@ -68,21 +75,24 @@ case class StatsdExporter(registry: Metrics, timer: Timer, prefix: String = "", 
     val counters = registry.sampleCounters().asScala
 
     counters.foreach {
-      case (name, value) => send(format(Seq(prefix, name), format(value.longValue()), "c"))
+      case (name, value) => format(writer, Seq(prefix, name), format(value.longValue()), "c")
     }
     gauges.foreach {
-      case (name, value) => send(format(Seq(prefix, name), format(value.longValue()), "g"))
+      case (name, value) => format(writer, Seq(prefix, name), format(value.longValue()), "g")
     }
 
     histos.foreach { case (name, snapshot) =>
-      send(format(Seq(prefix, name, "count"), format(snapshot.count), "g"))
-      send(format(Seq(prefix, name, "avg"), format(snapshot.avg), "t"))
-      send(format(Seq(prefix, name, "min"), format(snapshot.min), "t"))
-      send(format(Seq(prefix, name, "max"), format(snapshot.max), "t"))
-      send(format(Seq(prefix, name, "stddev"), format(snapshot.stddev), "t"))
+      format(writer, Seq(prefix, name, "count"), format(snapshot.count), "g")
+      format(writer, Seq(prefix, name, "avg"), format(snapshot.avg), "t")
+      format(writer, Seq(prefix, name, "min"), format(snapshot.min), "t")
+      format(writer, Seq(prefix, name, "max"), format(snapshot.max), "t")
+      format(writer, Seq(prefix, name, "stddev"), format(snapshot.stddev), "t")
       snapshot.percentiles.foreach(p =>
-        send(format(Seq(prefix, name, labelPercentile(p.getQuantile)), format(p.getValue), "t")))
+        format(writer, Seq(prefix, name, labelPercentile(p.getQuantile)), format(p.getValue), "t"))
     }
+
+    writer.close()
+    send(outputData.toString)
   }
 }
 

--- a/server/src/main/scala/com/lookout/borderpatrol/server/StatsdExporter.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/StatsdExporter.scala
@@ -10,7 +10,7 @@ import com.twitter.finagle.stats._
 import com.twitter.finagle.util.{HashedWheelTimer, InetSocketAddressUtil, DefaultTimer}
 import com.twitter.io.Buf
 import com.twitter.logging.Logger
-import com.twitter.util.{Duration, Timer, NonFatal}
+import com.twitter.util.{Time, Duration, Timer, NonFatal}
 import scala.collection.JavaConverters.mapAsScalaMapConverter
 import scala.collection.Map
 import scala.util.Try

--- a/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
@@ -461,7 +461,7 @@ class ConfigSpec extends BorderPatrolSuite {
       ("serviceIdentifiers", sids.asJson),
       ("loginManagers", (loginManagers +
         LoginManager("checkpoint", keymasterIdManager, keymasterAccessManager,
-          InternalAuthProtoManager(Path("/some"), Path("/some"), None))).asJson),
+          InternalAuthProtoManager("some", Path("/some"), Path("/some"), None))).asJson),
       ("identityManagers", Set(keymasterIdManager).asJson),
       ("accessManagers", Set(keymasterAccessManager).asJson)))
 

--- a/server/src/test/scala/com/lookout/borderpatrol/server/StatsdExporterSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/StatsdExporterSpec.scala
@@ -23,7 +23,7 @@ class StatsdExporterSpec extends BorderPatrolSuite {
   val defaultStatsdExporterConfig = StatsdExporterConfig(host, 300, "prefix")
 
   private[this] def receiveStat: Option[String] = {
-    val buf1 = ByteBuffer.allocateDirect(128)
+    val buf1 = ByteBuffer.allocateDirect(65536)
     server.receive(buf1)
     buf1.flip()
     val buf2 = Buf.ByteBuffer.Owned(buf1)
@@ -46,19 +46,21 @@ class StatsdExporterSpec extends BorderPatrolSuite {
 
   it should "report counter increment" in {
     val metrics1 = Metrics.createDetached()
-    val exporter1 = StatsdExporter(metrics1, HashedWheelTimer(),
-      "ut", Duration.fromSeconds(300), host)
+    val exporter1 = StatsdExporter(metrics1, HashedWheelTimer(), "ut", Duration.fromSeconds(300), host)
     val c = metrics1.createCounter("counter1")
     c.increment()
     exporter1.report()
-    receiveAllStats(Set.empty[String]).contains("ut.counter1:1|c") should be (true)
-    exporter1.timer.stop()
+    val stats = receiveAllStats(Set.empty[String])
+    try {
+      stats.filter(repo => repo.contains("ut.counter1:1|c")).nonEmpty should be (true)
+    } finally {
+      exporter1.timer.stop()
+    }
   }
 
   it should "report gauge increment" in {
     val metrics2 = Metrics.createDetached()
-    val exporter2 = StatsdExporter(metrics2, HashedWheelTimer(),
-      "ut", Duration.fromSeconds(300), host)
+    val exporter2 = StatsdExporter(metrics2, HashedWheelTimer(), "ut", Duration.fromSeconds(300), host)
     var x = 0
     val g = new AbstractGauge[Number]("gauge1") {
       def read: Number = x
@@ -67,29 +69,35 @@ class StatsdExporterSpec extends BorderPatrolSuite {
     x = 10
     exporter2.report()
     Thread.sleep(100)
-    receiveAllStats(Set.empty[String]).contains("ut.gauge1:10|g") should be (true)
-    exporter2.timer.stop()
+    val stats = receiveAllStats(Set.empty[String])
+    try {
+      stats.filter(repo => repo.contains("ut.gauge1:10|g")).nonEmpty should be (true)
+    } finally {
+      exporter2.timer.stop()
+    }
   }
 
   it should "report historgram increment" in {
     val metrics3 = Metrics.createDetached()
-    val exporter3 = StatsdExporter(metrics3, HashedWheelTimer(),
-      "ut", Duration.fromSeconds(300), host)
+    val exporter3 = StatsdExporter(metrics3, HashedWheelTimer(), "ut", Duration.fromSeconds(300), host)
     val r = new scala.util.Random(10000)
     val histo = metrics3.createHistogram("histo")
     exporter3.report()
     val stats = receiveAllStats(Set.empty[String])
-    stats.contains("ut.histo.count:0|g") should be (true)
-    stats.contains("ut.histo.avg:0.00|t") should be (true)
-    stats.contains("ut.histo.min:0|t") should be (true)
-    stats.contains("ut.histo.max:0|t") should be (true)
-    stats.contains("ut.histo.stddev:0.00|t") should be (true)
-    stats.contains("ut.histo.p50:0|t") should be (true)
-    stats.contains("ut.histo.p90:0|t") should be (true)
-    stats.contains("ut.histo.p95:0|t") should be (true)
-    stats.contains("ut.histo.p99:0|t") should be (true)
-    stats.contains("ut.histo.p999:0|t") should be (true)
-    stats.contains("ut.histo.p9999:0|t") should be (true)
-    exporter3.timer.stop()
+    try {
+      stats.filter(repo => repo.contains("ut.histo.count:0|g")).nonEmpty should be (true)
+      stats.filter(repo => repo.contains("ut.histo.avg:0.00|t")).nonEmpty should be (true)
+      stats.filter(repo => repo.contains("ut.histo.min:0|t")).nonEmpty should be (true)
+      stats.filter(repo => repo.contains("ut.histo.max:0|t")).nonEmpty should be (true)
+      stats.filter(repo => repo.contains("ut.histo.stddev:0.00|t")).nonEmpty should be (true)
+      stats.filter(repo => repo.contains("ut.histo.p50:0|t")).nonEmpty should be (true)
+      stats.filter(repo => repo.contains("ut.histo.p90:0|t")).nonEmpty should be (true)
+      stats.filter(repo => repo.contains("ut.histo.p95:0|t")).nonEmpty should be (true)
+      stats.filter(repo => repo.contains("ut.histo.p99:0|t")).nonEmpty should be (true)
+      stats.filter(repo => repo.contains("ut.histo.p999:0|t")).nonEmpty should be (true)
+      stats.filter(repo => repo.contains("ut.histo.p9999:0|t")).nonEmpty should be (true)
+    } finally {
+      exporter3.timer.stop()
+    }
   }
 }

--- a/server/src/test/scala/com/lookout/borderpatrol/server/StatsdExporterSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/StatsdExporterSpec.scala
@@ -4,9 +4,8 @@ import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.channels.DatagramChannel
 
-import com.lookout.borderpatrol.BinderBase
 import com.lookout.borderpatrol.test.BorderPatrolSuite
-import com.twitter.finagle.util.{HashedWheelTimer, DefaultTimer}
+import com.twitter.finagle.util.{HashedWheelTimer}
 import com.twitter.io.Buf
 import com.twitter.common.metrics.{AbstractGauge, Metrics}
 import com.twitter.util.Duration


### PR DESCRIPTION
- Add labels to connection metrics (it makes metrics readable)
- Fix CustomerIdFilter, SessionIdFilter and AccessFilter to reduce the handle time
  (i.e. time to setup the futures in the filter chain, i.e. time consumed by a
  thread to process the incoming request; reduced from 800 us to 150 us)
- Fix StatsdExporter to report all the stats in a single DatagramPacket, instead
  of multiple writes