### PR TITLE
Use Request ParamMap instead of req.uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
 
 ```scala
 libraryDependencies ++= Seq(
-  "com.lookout.borderpatrol" %% "[borderpatrol-module]" % "0.1.18-SNAPSHOT"
+  "com.lookout.borderpatrol" %% "[borderpatrol-module]" % "0.1.20-SNAPSHOT"
 )
 ```
 
@@ -108,8 +108,7 @@ Configuration
 -------------
 
  * `secretStore`: Secret Store. It can be configured using `type` as `InMemorySecretStore` or `ConsulSecretStore`.
-   * `InMemorySecretStore`: Typically used for single host setup as Secrets are meant to be shared across all the
-BorderPatrol nodes
+   * `InMemorySecretStore`: Typically used for single host setup as Secrets are meant to be shared across all the BorderPatrol nodes
      ```json
      "secretStore" : {
        "type" : "InMemorySecretStore",
@@ -126,8 +125,7 @@ BorderPatrol nodes
      }
      ```
  * `sessionStore`: Session Store. It can be configured using `type` as `InMemoryStore` or `MemcachedStore`.
-   * `InMemoryStore`: Typically used for single host setup as Sessions are meant to be shared across all the
-BorderPatrol nodes.
+   * `InMemoryStore`: Typically used for single host setup as Sessions are meant to be shared across all the BorderPatrol nodes.
      ```json
      "sessionStore" : {
        "type" : "InMemoryStore",
@@ -179,7 +177,7 @@ this service
  * `customerIdentifier`:
    * `loginManager`: Login Manager or policy used by this customer identifier
    * `subdomain`: A subdomain represented by this identifier
-   * `defaultServiceIdentifier`: The default service for this customer identifier
+   * `defaultServiceIdentifier`: The default "protected" service for this customer identifier
  * `statdReporter`: The statsd reporter configuration
    * `host`: Upstream statsd endpoint
    * `durationInSec`: Reporting frequency in Seconds.

--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/keymaster/Keymaster.scala
@@ -91,14 +91,15 @@ object Keymaster {
   case class KeymasterTransformFilter(oAuth2CodeVerify: OAuth2CodeVerify)(implicit statsReceiver: StatsReceiver)
       extends Filter[BorderRequest, Response, KeymasterIdentifyReq, Response] {
 
-    def transformInternal(req: BorderRequest): Future[InternalAuthCredential] =
+    def transformInternal(req: BorderRequest): Future[InternalAuthCredential] = {
       (for {
-        u <- Helpers.scrubQueryParams(req.req.uri, "username")
-        p <- Helpers.scrubQueryParams(req.req.uri, "password")
+        u <- Helpers.scrubQueryParams(req.req.params, "username")
+        p <- Helpers.scrubQueryParams(req.req.params, "password")
       } yield InternalAuthCredential(u, p, req.customerId, req.serviceId)) match {
         case Some(c) => Future.value(c)
         case None => Future.exception(new BpBadRequest("Failed to find username and/or password in the Request"))
       }
+    }
 
     def transformOAuth2(req: BorderRequest, protoManager: OAuth2CodeProtoManager): Future[OAuth2CodeCredential] = {
       for {

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.1.19-SNAPSHOT"
+lazy val Version = "0.1.20-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/Manager.scala
@@ -75,7 +75,7 @@ case class OAuth2CodeProtoManager(name: String, loginConfirm: Path, authorizeUrl
     val request = util.Combinators.tap(Request(Method.Post, tokenUrl.toString))(re => {
       re.contentType = "application/x-www-form-urlencoded"
       re.contentString = Request.queryString(("grant_type", "authorization_code"), ("client_id", clientId),
-        ("code", Helpers.scrubQueryParams(req.uri, "code")
+        ("code", Helpers.scrubQueryParams(req.params, "code")
           .getOrElse(throw new Exception(s"OAuth2 code not found in HTTP ${req}"))),
         ("redirect_uri", "http://" + hostStr + loginConfirm.toString),
         ("client_secret", clientSecret), ("resource", "00000002-0000-0000-c000-000000000000"))

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
@@ -167,7 +167,7 @@ case class SendToIdentityProvider(identityProviderMap: Map[String, Service[Borde
         if Path(req.req.path).startsWith(req.customerId.loginManager.protoManager.loginConfirm) => {
         for {
           sessionId <- SignedId.untagged
-          location <- Helpers.scrubQueryParams(req.req.uri, "target_url")
+          location <- Helpers.scrubQueryParams(req.req.params, "target_url")
             .getOrElse(req.customerId.defaultServiceId.path.toString).toFuture
           savedReq <- tap(Request(location))(r => r.addCookie(sessionId.asCookie())).toFuture
           session <- Session(sessionId, savedReq).toFuture
@@ -286,7 +286,7 @@ case class LogoutService(store: SessionStore)(implicit secretStore: SecretStoreA
       store.delete(sid)
     })
     // Redirect to suggested url or the logged out path or default service
-    val location = Helpers.scrubQueryParams(req.req.uri, "destination")
+    val location = Helpers.scrubQueryParams(req.req.params, "destination")
       .fold(req.customerId.defaultServiceId.path.toString)(_.toString)
 
     Future.exception(BpLogoutError(Status.Ok, location,

--- a/core/src/main/scala/com/lookout/borderpatrol/util/Helpers.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/util/Helpers.scala
@@ -1,35 +1,20 @@
 package com.lookout.borderpatrol.util
 
-import org.jboss.netty.handler.codec.http.QueryStringDecoder
+import com.twitter.finagle.http.ParamMap
 
-import scala.collection.JavaConverters._
-import scala.util.{Success, Try}
 
 object Helpers {
 
-  /** Parse uri into (path, params) */
+  /** Regular Expression for all special characters from ASCII 0 to 20 */
   private[this] val specialCharRegEx = (for (i <- 0 to 20) yield f"\\x$i%02x").mkString("[", "", "]")
 
-  def scrubQueryParams(uri: String, paramKey: String): Option[String] = {
-    Try(new QueryStringDecoder(uri)) match {
-      case Success(qsd) =>
-        /* Convert to a scala parameter map (key, List<values>) */
-        val params = qsd.getParameters.asScala.mapValues {
-          _.asScala.toList
-        }
-        /* Lookup list of query param values for the given param key */
-        params.get(paramKey).flatMap { l =>
-          /* These param values could be malformed and may contain special characters. So lets scrub them out and
-           * choose the first valid string for each row in the list
-           */
-          val listOfValues = l.flatMap { s =>
-            s.split(specialCharRegEx).filterNot(_.isEmpty).headOption
-          }
-          if (listOfValues.isEmpty) None
-          else Some(listOfValues.mkString("_"))
-        }
-      case _ => None
+  def scrubQueryParams(params: ParamMap, paramKey: String): Option[String] = {
+    /* Lookup query param value for the given param key */
+    params.get(paramKey).flatMap { l =>
+      /* These param values could be malformed and may contain special characters. So lets scrub them out and
+       * choose the first valid string as param
+       */
+      l.split(specialCharRegEx).filterNot(_.isEmpty).headOption
     }
   }
-
 }

--- a/core/src/main/scala/com/lookout/borderpatrol/util/Helpers.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/util/Helpers.scala
@@ -5,8 +5,8 @@ import com.twitter.finagle.http.ParamMap
 
 object Helpers {
 
-  /** Regular Expression for all special characters from ASCII 0 to 20 */
-  private[this] val specialCharRegEx = (for (i <- 0 to 20) yield f"\\x$i%02x").mkString("[", "", "]")
+  /** Regular Expression for all special characters from ASCII 0 to 32 */
+  private[this] val specialCharRegEx = (for (i <- 0 to 32) yield f"\\x$i%02x").mkString("[", "", "]")
 
   def scrubQueryParams(params: ParamMap, paramKey: String): Option[String] = {
     /* Lookup query param value for the given param key */

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
@@ -719,7 +719,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
   it should "send request w/ auth SessionId to unprotected upstream service path" in {
     val testService = mkTestService[SessionIdRequest, Response] { _ => fail("Must not invoke this service") }
     val testSidBinder = mkTestSidBinder { req => {
-      assert(req.context == checkpointSid)
+      assert(req.context == unproCheckpointSid)
       Response(Status.Ok).toFuture
     }}
 
@@ -731,7 +731,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
 
     // Original request
     val output = (SendToUnprotectedService(testSidBinder) andThen testService)(
-      SessionIdRequest(request, cust1, Some(checkpointSid), Some(sessionId)))
+      SessionIdRequest(request, cust1, Some(unproCheckpointSid), Some(sessionId)))
 
     //  Validate
     Await.result(output).status should be (Status.Ok)
@@ -740,7 +740,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
   it should "send request w/ unauth SessionId to unprotected upstream service path" in {
     val testService = mkTestService[SessionIdRequest, Response] { _ => fail("Must not invoke this service") }
     val testSidBinder = mkTestSidBinder { req => {
-      assert(req.context == checkpointSid)
+      assert(req.context == unproCheckpointSid)
       Response(Status.Ok).toFuture
     }}
 
@@ -752,7 +752,7 @@ class BorderAuthSpec extends BorderPatrolSuite  {
 
     // Original request
     val output = (SendToUnprotectedService(testSidBinder) andThen testService)(
-      SessionIdRequest(request, cust1, Some(checkpointSid), Some(sessionId)))
+      SessionIdRequest(request, cust1, Some(unproCheckpointSid), Some(sessionId)))
 
     //  Validate
     Await.result(output).status should be (Status.Ok)

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/helpers.scala
@@ -92,9 +92,11 @@ object helpers {
   val cust2 = CustomerIdentifier("sky", two, umbrellaLoginManager)
   val three = ServiceIdentifier("three", urls, Path("/rain"), None, true)
   val cust3 = CustomerIdentifier("rainy", three, rainyLoginManager)
-  val checkpointSid = ServiceIdentifier("checkpoint", urls, Path("/check"), None, false)
-  val cids = Set(cust1, cust2, cust3)
-  val sids = Set(one, oneTwo, two, three, checkpointSid)
+  val unproCheckpointSid = ServiceIdentifier("login", urls, Path("/check"), None, false)
+  val proCheckpointSid = ServiceIdentifier("checkpoint", urls, Path("/check/that"), None, true)
+  val cust4 = CustomerIdentifier("repeat", proCheckpointSid, checkpointLoginManager)
+  val cids = Set(cust1, cust2, cust3, cust4)
+  val sids = Set(one, oneTwo, two, three, proCheckpointSid, unproCheckpointSid)
   val serviceMatcher = ServiceMatcher(cids, sids)
   val sessionStore = SessionStores.InMemoryStore
 

--- a/core/src/test/scala/com/lookout/borderpatrol/test/util/HelpersSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/util/HelpersSpec.scala
@@ -17,7 +17,7 @@ class HelpersSpec extends BorderPatrolSuite {
 
   it should "scrub the special characters from the encoded query params of GET Request URI" in {
     /* Query encoded GET URLs */
-    val req1 = Request("logout?destination=/abc%0d%0atest:abc%0d%0a&blah=/abc%0d%0atest2:abc2%0d%0a")
+    val req1 = Request("logout?destination=%20/abc%0d%0a%20test:abc%0d%0a&blah=/abc%0d%0atest2:abc2%0d%0a")
     scrubQueryParams(req1.params, "destination") should be(Some("/abc"))
     val req2 = Request("logout?destination=/abc%0d%0atest:abc%0d%0a")
     scrubQueryParams(req2.params, "destination") should be(Some("/abc"))

--- a/core/src/test/scala/com/lookout/borderpatrol/test/util/HelpersSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/util/HelpersSpec.scala
@@ -1,48 +1,91 @@
 package com.lookout.borderpatrol.test
 
+import com.lookout.borderpatrol.util.Combinators._
 import com.lookout.borderpatrol.util.Helpers._
+import com.twitter.finagle.http.{Method, Request}
 
 
 class HelpersSpec extends BorderPatrolSuite {
 
+  def toPostRequest(uri: String): Request =
+    tap(Request(Method.Post, "/"))(req => {
+      req.contentType = "application/x-www-form-urlencoded"
+      req.contentString = uri
+    })
+
   behavior of "scrubQueryParams"
 
-  it should "scrub the special characters from the query params" in {
-    /* Query encoded URLs */
-    val req1 = "https://mtp.lookout.com/logout?destination=/abc%0d%0atest:abc%0d%0a&blah=/abc%0d%0atest2:abc2%0d%0a"
-    scrubQueryParams(req1, "destination") should be(Some("/abc"))
-    val req2 = "https://mtp.lookout.com/logout?destination=/abc%0d%0atest:abc%0d%0a"
-    scrubQueryParams(req2, "destination") should be(Some("/abc"))
-    val req3 = "https://mtp.lookout.com/logout?destination=/abc%0d%0a"
-    scrubQueryParams(req3, "destination") should be(Some("/abc"))
-    val req4 = "https://mtp.lookout.com/logout?destination=/%0d%0aabc%0d%0a"
-    scrubQueryParams(req4, "destination") should be(Some("/"))
-
-    /* URLs w/o encoding */
-    val req11 = "https://mtp.lookout.com/logout?destination=/abc\n\rtest:abc\n\r&blah=/abc\n\rtest2:abc2\n\r"
-    scrubQueryParams(req11, "destination") should be(Some("/abc"))
-    val req12 = "https://mtp.lookout.com/logout?destination=/abc\n\rtest:abc\n\r"
-    scrubQueryParams(req12, "destination") should be(Some("/abc"))
-    val req13 = "https://mtp.lookout.com/logout?destination=/abc\n\r"
-    scrubQueryParams(req13, "destination") should be(Some("/abc"))
-    val req14 = "https://mtp.lookout.com/logout?destination=/\n\rabc\n\r"
-    scrubQueryParams(req14, "destination") should be(Some("/"))
-    val req15 = "https://mtp.lookout.com/logout?destination=/abc\r"
-    scrubQueryParams(req15, "destination") should be(Some("/abc"))
-    val req16 = "https://mtp.lookout.com/logout?destination=/abc\n\r"
-    scrubQueryParams(req16, "destination") should be(Some("/abc"))
-    val req17 = "https://mtp.lookout.com/logout?destination=/abc\n"
-    scrubQueryParams(req17, "destination") should be(Some("/abc"))
-    val req18 = "https://mtp.lookout.com/logout?destination=\n\r/abc"
-    scrubQueryParams(req18, "destination") should be(Some("/abc"))
+  it should "scrub the special characters from the encoded query params of GET Request URI" in {
+    /* Query encoded GET URLs */
+    val req1 = Request("logout?destination=/abc%0d%0atest:abc%0d%0a&blah=/abc%0d%0atest2:abc2%0d%0a")
+    scrubQueryParams(req1.params, "destination") should be(Some("/abc"))
+    val req2 = Request("logout?destination=/abc%0d%0atest:abc%0d%0a")
+    scrubQueryParams(req2.params, "destination") should be(Some("/abc"))
+    val req3 = Request("logout?destination=/abc%0d%0a")
+    scrubQueryParams(req3.params, "destination") should be(Some("/abc"))
+    val req4 = Request("logout?destination=/%0d%0aabc%0d%0a")
+    scrubQueryParams(req4.params, "destination") should be(Some("/"))
 
     /* Error conditions */
-    scrubQueryParams(req1, "foo") should be(None)
-    scrubQueryParams(null, "foo") should be(None)
-    scrubQueryParams(req1, null) should be(None)
-    val req21 = "https://mtp.lookout.com/logout?destination="
-    scrubQueryParams(req21, "destination") should be(None)
-    val req22 = "https://mtp.lookout.com/logout?destination=\n\r"
-    scrubQueryParams(req22, "destination") should be(None)
+    scrubQueryParams(req1.params, "foo") should be(None)
+    scrubQueryParams(req1.params, null) should be(None)
+  }
+
+  it should "scrub the special characters from the query params of GET Request URI" in {
+    /* URLs w/o encoding */
+    val req11 = Request("logout?destination=/abc\n\rtest:abc\n\r&blah=/abc\n\rtest2:abc2\n\r")
+    scrubQueryParams(req11.params, "destination") should be(Some("/abc"))
+    val req12 = Request("logout?destination=/abc\n\rtest:abc\n\r")
+    scrubQueryParams(req12.params, "destination") should be(Some("/abc"))
+    val req13 = Request("logout?destination=/abc\n\r")
+    scrubQueryParams(req13.params, "destination") should be(Some("/abc"))
+    val req14 = Request("logout?destination=/\n\rabc\n\r")
+    scrubQueryParams(req14.params, "destination") should be(Some("/"))
+    val req15 = Request("logout?destination=/abc\r")
+    scrubQueryParams(req15.params, "destination") should be(Some("/abc"))
+    val req16 = Request("logout?destination=/abc\n\r")
+    scrubQueryParams(req16.params, "destination") should be(Some("/abc"))
+    val req17 = Request("logout?destination=/abc\n")
+    scrubQueryParams(req17.params, "destination") should be(Some("/abc"))
+    val req18 = Request("logout?destination=\n\r/abc")
+    scrubQueryParams(req18.params, "destination") should be(Some("/abc"))
+    val req19 = Request("logout?destination=")
+    scrubQueryParams(req19.params, "destination") should be(None)
+    val req20 = Request("logout?destination=\n\r")
+    scrubQueryParams(req20.params, "destination") should be(None)
+  }
+
+  it should "scrub the special characters from the encoded query params of POST Request URI" in {
+    /* Query encoded POST URLs */
+    val req30 = toPostRequest("destination=/abc")
+    scrubQueryParams(req30.params, "destination") should be(Some("/abc"))
+    val req31 = toPostRequest("destination=/abc%0d%0atest:abc%0d%0a&blah=/abc%0d%0atest2:abc2%0d%0a")
+    scrubQueryParams(req31.params, "destination") should be(Some("/abc"))
+    val req32 = toPostRequest("destination=/abc%0d%0atest:abc%0d%0a")
+    scrubQueryParams(req32.params, "destination") should be(Some("/abc"))
+    val req33 = toPostRequest("destination=/abc%0d%0a")
+    scrubQueryParams(req33.params, "destination") should be(Some("/abc"))
+    val req34 = toPostRequest("destination=/%0d%0aabc%0d%0a")
+    scrubQueryParams(req34.params, "destination") should be(Some("/"))
+  }
+
+  it should "scrub the special characters from the query params of POST Request URI" in {
+    /* URLs w/o POST encoding */
+    val req41 = toPostRequest("destination=/abc\n\rtest:abc\n\r&blah=/abc\n\rtest2:abc2\n\r")
+    scrubQueryParams(req41.params, "destination") should be(Some("/abc"))
+    val req42 = toPostRequest("destination=/abc\n\rtest:abc\n\r")
+    scrubQueryParams(req42.params, "destination") should be(Some("/abc"))
+    val req43 = toPostRequest("destination=/abc\n\r")
+    scrubQueryParams(req43.params, "destination") should be(Some("/abc"))
+    val req44 = toPostRequest("destination=/\n\rabc\n\r")
+    scrubQueryParams(req44.params, "destination") should be(Some("/"))
+    val req45 = toPostRequest("destination=/abc\r")
+    scrubQueryParams(req45.params, "destination") should be(Some("/abc"))
+    val req46 = toPostRequest("destination=/abc\n\r")
+    scrubQueryParams(req46.params, "destination") should be(Some("/abc"))
+    val req47 = toPostRequest("destination=/abc\n")
+    scrubQueryParams(req47.params, "destination") should be(Some("/abc"))
+    val req48 = toPostRequest("destination=\n\r/abc")
+    scrubQueryParams(req48.params, "destination") should be(Some("/abc"))
   }
 }

--- a/security/src/main/scala/com/lookout/borderpatrol/security/Csrf.scala
+++ b/security/src/main/scala/com/lookout/borderpatrol/security/Csrf.scala
@@ -40,7 +40,7 @@ object Csrf {
      */
     def verify(req: Request): Boolean =
       (for {
-        str <- req.headerMap.get(header.header) orElse Helpers.scrubQueryParams(req.uri, param.param)
+        str <- req.headerMap.get(header.header) orElse Helpers.scrubQueryParams(req.params, param.param)
         uid <- SignedId.from(str).toOption
         cid <- SignedId.fromRequest(req, cookieName.name).toOption
       } yield uid == cid) getOrElse false

--- a/security/src/main/scala/com/lookout/borderpatrol/security/Csrf.scala
+++ b/security/src/main/scala/com/lookout/borderpatrol/security/Csrf.scala
@@ -9,7 +9,7 @@ import com.twitter.util.{Time, Future}
 
 object Csrf {
   case class InHeader(val header: String = "X-BORDER-CSRF") extends AnyVal
-  case class Param(val param: String = "_x_border_csrf") extends AnyVal
+  case class CsrfToken(val value: String = "_x_border_csrf") extends AnyVal
   case class CookieName(val name: String = "border_csrf") extends AnyVal
   case class VerifiedHeader(val header: String = "X-BORDER-CSRF-VERIFIED") extends AnyVal
 
@@ -17,12 +17,12 @@ object Csrf {
    * Informs upstream service about Csrf validation via double submit cookie
    *
    * @param header The incoming header that contains the CSRF token
-   * @param param The incoming parameter that contains the CSRF token
+   * @param csrfToken The incoming parameter that contains the CSRF token
    * @param cookieName The cookie that contains the CSRF token
    * @param verifiedHeader The verified header to set
    */
   case class Verify(header: InHeader,
-                    param: Param,
+                    csrfToken: CsrfToken,
                     cookieName: CookieName,
                     verifiedHeader: VerifiedHeader)(implicit secretStoreApi: SecretStoreApi) {
 
@@ -40,7 +40,7 @@ object Csrf {
      */
     def verify(req: Request): Boolean =
       (for {
-        str <- req.headerMap.get(header.header) orElse Helpers.scrubQueryParams(req.params, param.param)
+        str <- req.headerMap.get(header.header) orElse Helpers.scrubQueryParams(req.params, csrfToken.value)
         uid <- SignedId.from(str).toOption
         cid <- SignedId.fromRequest(req, cookieName.name).toOption
       } yield uid == cid) getOrElse false

--- a/security/src/test/scala/com/lookout/borderpatrol/test/security/CsrfSpec.scala
+++ b/security/src/test/scala/com/lookout/borderpatrol/test/security/CsrfSpec.scala
@@ -13,8 +13,8 @@ class CsrfSpec extends BorderPatrolSuite {
   val csrf1 = sessionid.untagged.asBase64
   val csrf2 = sessionid.untagged.asBase64
 
-  val (header, param, cookiename, verified) = ("header", "param", "cookieName", "verified")
-  val verify = Verify(InHeader(header), Param(param), CookieName(cookiename), VerifiedHeader(verified))
+  val (header, csrfTokenValue, cookiename, verified) = ("header", "x_csrf_token", "cookieName", "verified")
+  val verify = Verify(InHeader(header), CsrfToken(csrfTokenValue), CookieName(cookiename), VerifiedHeader(verified))
 
   val filter = CsrfVerifyFilter(verify)
 
@@ -38,7 +38,7 @@ class CsrfSpec extends BorderPatrolSuite {
   }
 
   def requestWithParam: Request = {
-    val req = Request("/", param -> csrf1)
+    val req = Request("/", csrfTokenValue -> csrf1)
     req.addCookie(new Cookie(cookiename, csrf1))
     req
   }
@@ -68,7 +68,7 @@ class CsrfSpec extends BorderPatrolSuite {
 
   it should "set verified header as false when Csrf header or param is set incorrectly" in {
     val req1 = requestWithHeader
-    val req2 = Request("/", param -> csrf2)
+    val req2 = Request("/", csrfTokenValue -> csrf2)
     req1.headerMap.update(header, csrf2)
     req2.addCookie(new Cookie(cookiename, csrf1))
 

--- a/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
@@ -481,7 +481,8 @@ class ConfigSpec extends BorderPatrolSuite {
       ("sessionStore", defaultSessionStore.asInstanceOf[SessionStore].asJson),
       ("statsdReporter", defaultStatsdExporterConfig.asJson),
       ("customerIdentifiers", cids.asJson),
-      ("serviceIdentifiers", (sids + ServiceIdentifier("some", urls, Path("/ent"), None, false)).asJson),
+      ("serviceIdentifiers", (sids + ServiceIdentifier("some", urls, Path("/ent"), None, false)
+        + ServiceIdentifier("some", urls, Path("/some"), None, false)).asJson),
       ("loginManagers", loginManagers.asJson),
       ("identityManagers", Set(keymasterIdManager).asJson),
       ("accessManagers", Set(keymasterAccessManager).asJson)))


### PR DESCRIPTION
- since it fetches query param from uri (GET) or contentString (POST)

Also,
- Log an error message if we see multiple ServiceIdentifiers for a
  tuple of (service name and protected flag.