### PR TITLE
Use destination as a query param, instead of target_url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ scala:
 jdk:
 - oraclejdk7
 - oraclejdk8
-script: sbt ++$TRAVIS_SCALA_VERSION clean coverage test scalastyle && sbt ++$TRAVIS_SCALA_VERSION
-  coverageAggregate
+script: sbt ++$TRAVIS_SCALA_VERSION clean coverage test scalastyle && sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
 notifications:
   webhooks:
     urls:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
 
 ```scala
 libraryDependencies ++= Seq(
-  "com.lookout.borderpatrol" %% "[borderpatrol-module]" % "0.1.20-SNAPSHOT"
+  "com.lookout.borderpatrol" %% "[borderpatrol-module]" % "0.1.21-SNAPSHOT"
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.1.20-SNAPSHOT"
+lazy val Version = "0.1.21-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
@@ -87,7 +87,7 @@ object service {
           /* If authenticated and protected service, send it via Access Issuer chain */
           SendToAccessIssuer(accessIssuerChainMap(config.sessionStore)) andThen
           /* Authenticated or not, send it to unprotected service, if its destined to that */
-          SendToUnprotectedService(ServiceIdentifierBinder) andThen
+          SendToUnprotectedService(ServiceIdentifierBinder, config.sessionStore) andThen
           /* Not found */
           notFoundService
     }


### PR DESCRIPTION
Also,
- if user attempts goto login page directly, then after authentication, redirect it to default service
- removed some of the benign operations executed in the Future contexts