### PR TITLE
Move LoginManager's encoder-decoder to example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.4-SNAPSHOT"
+lazy val Version = "0.2.5-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/server/src/main/scala/com/lookout/borderpatrol/server/Config.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/Config.scala
@@ -76,10 +76,6 @@ object Config {
    * Note that Decoder for LoginManager does not work standalone, it can be only used
    * while decoding the entire Config due to dependency issues
    */
-  implicit val encodeLoginManager: Encoder[LoginManager] = Encoder.instance {
-    case blm: BasicLoginManager => blm.asJson
-    case olm: OAuth2LoginManager => olm.asJson
-  }
   implicit val encodeBasicLoginManager: Encoder[BasicLoginManager] = Encoder.instance { blm =>
     Json.fromFields(Seq(
       ("name", blm.name.asJson),
@@ -105,12 +101,6 @@ object Config {
       ("clientId", olm.clientId.asJson),
       ("clientSecret", olm.clientSecret.asJson)
     ))
-  }
-  def decodeLoginManager(eps: Map[String, Endpoint]): Decoder[LoginManager] = Decoder.instance { c =>
-    c.downField("type").as[String].flatMap {
-      case "tokenmaster.basic" => decodeBasicLoginManager(eps).apply(c)
-      case "tokenmaster.oauth2" => decodeOAuth2LoginManager(eps).apply(c)
-    }
   }
   def decodeBasicLoginManager(eps: Map[String, Endpoint]): Decoder[BasicLoginManager] = Decoder.instance { c =>
     for {


### PR DESCRIPTION
- The LoginManager is a base class for differnet auth types
- Currently only 2 types (base and oauth2) are defined in this repository
- The app (e.g. example app in this case) can add more types
- To do so moving implicit base encoder and decoder to example