### PR TITLE
Fix metric type and do not print query params in location in log

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/tokenmaster/Tokenmaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/tokenmaster/Tokenmaster.scala
@@ -147,7 +147,7 @@ object Tokenmaster {
         BorderAuth.formatRedirectResponse(req.req, Status.Ok, originReq.uri, Some(session.id),
           s"Session: ${req.sessionId.toLogIdString}} is authenticated, " +
             s"allocated new Session: ${session.id.toLogIdString} and redirecting to " +
-            s"location: ${originReq.uri}")
+            s"location: ${originReq.path}")
       }
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.5-SNAPSHOT"
+lazy val Version = "0.2.6-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
@@ -196,7 +196,7 @@ case class SendToIdentityProvider(identityProviderMap: Map[String, Service[Borde
         statLoginRedirects.incr()
         BorderAuth.formatRedirectResponse(req.req, Status.Unauthorized, location, Some(sessionId),
           s"Redirecting the ${req.req} for Untagged Session: ${sessionId.toLogIdString} " +
-            s"to login service, location: ${location}")
+            s"to login service, location: ${location.split('?').headOption}")
       }
   }
 
@@ -387,7 +387,8 @@ case class IdentityFilter[A : SessionDataEncoder](store: SessionStore)(
         val location = req.customerId.loginManager.redirectLocation(req.req)
         BorderAuth.formatRedirectResponse(req.req, Status.Unauthorized, location, Some(session.id),
           s"Failed to find Session: ${req.sessionId.toLogIdString} for: ${req.req}, " +
-            s"allocating a new session: ${session.id.toLogIdString}, redirecting to location: ${location}")
+            s"allocating a new session: ${session.id.toLogIdString}, " +
+            s"redirecting to location: ${location.split('?').headOption}")
       }
     }
   }

--- a/server/src/main/scala/com/lookout/borderpatrol/server/StatsdExporter.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/StatsdExporter.scala
@@ -89,12 +89,12 @@ case class StatsdExporter(registry: Metrics, timer: Timer, prefix: String = "", 
 
     histos.foreach { case (name, snapshot) =>
       send(format(Seq(prefix, name, "count"), format(snapshot.count), "g"))
-      send(format(Seq(prefix, name, "avg"), format(snapshot.avg), "t"))
-      send(format(Seq(prefix, name, "min"), format(snapshot.min), "t"))
-      send(format(Seq(prefix, name, "max"), format(snapshot.max), "t"))
-      send(format(Seq(prefix, name, "stddev"), format(snapshot.stddev), "t"))
+      send(format(Seq(prefix, name, "avg"), format(snapshot.avg), "g"))
+      send(format(Seq(prefix, name, "min"), format(snapshot.min), "g"))
+      send(format(Seq(prefix, name, "max"), format(snapshot.max), "g"))
+      send(format(Seq(prefix, name, "stddev"), format(snapshot.stddev), "g"))
       snapshot.percentiles.foreach(p =>
-        send(format(Seq(prefix, name, labelPercentile(p.getQuantile)), format(p.getValue), "t")))
+        send(format(Seq(prefix, name, labelPercentile(p.getQuantile)), format(p.getValue), "g")))
     }
 
     /** Flush the data buffer in the end */

--- a/server/src/test/scala/com/lookout/borderpatrol/server/StatsdExporterSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/StatsdExporterSpec.scala
@@ -50,7 +50,7 @@ class StatsdExporterSpec extends BorderPatrolSuite {
     exporter1.report()
     val stats = receiveAllStats(Set.empty[String])
     try {
-      stats.filter(repo => repo.contains("ut.counter1:1|c")).nonEmpty should be (true)
+      stats.exists(repo => repo.contains("ut.counter1:1|c")) should be (true)
     } finally {
       exporter1.timer.stop()
     }
@@ -69,7 +69,7 @@ class StatsdExporterSpec extends BorderPatrolSuite {
     Thread.sleep(100)
     val stats = receiveAllStats(Set.empty[String])
     try {
-      stats.filter(repo => repo.contains("ut.gauge1:10|g")).nonEmpty should be (true)
+      stats.exists(repo => repo.contains("ut.gauge1:10|g")) should be (true)
     } finally {
       exporter2.timer.stop()
     }
@@ -83,17 +83,17 @@ class StatsdExporterSpec extends BorderPatrolSuite {
     exporter3.report()
     val stats = receiveAllStats(Set.empty[String])
     try {
-      stats.filter(repo => repo.contains("ut.histo.count:0|g")).nonEmpty should be (true)
-      stats.filter(repo => repo.contains("ut.histo.avg:0.00|t")).nonEmpty should be (true)
-      stats.filter(repo => repo.contains("ut.histo.min:0|t")).nonEmpty should be (true)
-      stats.filter(repo => repo.contains("ut.histo.max:0|t")).nonEmpty should be (true)
-      stats.filter(repo => repo.contains("ut.histo.stddev:0.00|t")).nonEmpty should be (true)
-      stats.filter(repo => repo.contains("ut.histo.p50:0|t")).nonEmpty should be (true)
-      stats.filter(repo => repo.contains("ut.histo.p90:0|t")).nonEmpty should be (true)
-      stats.filter(repo => repo.contains("ut.histo.p95:0|t")).nonEmpty should be (true)
-      stats.filter(repo => repo.contains("ut.histo.p99:0|t")).nonEmpty should be (true)
-      stats.filter(repo => repo.contains("ut.histo.p999:0|t")).nonEmpty should be (true)
-      stats.filter(repo => repo.contains("ut.histo.p9999:0|t")).nonEmpty should be (true)
+      stats.exists(repo => repo.contains("ut.histo.count:0|g")) should be (true)
+      stats.exists(repo => repo.contains("ut.histo.avg:0.00|g")) should be (true)
+      stats.exists(repo => repo.contains("ut.histo.min:0|g")) should be (true)
+      stats.exists(repo => repo.contains("ut.histo.max:0|g")) should be (true)
+      stats.exists(repo => repo.contains("ut.histo.stddev:0.00|g")) should be (true)
+      stats.exists(repo => repo.contains("ut.histo.p50:0|g")) should be (true)
+      stats.exists(repo => repo.contains("ut.histo.p90:0|g")) should be (true)
+      stats.exists(repo => repo.contains("ut.histo.p95:0|g")) should be (true)
+      stats.exists(repo => repo.contains("ut.histo.p99:0|g")) should be (true)
+      stats.exists(repo => repo.contains("ut.histo.p999:0|g")) should be (true)
+      stats.exists(repo => repo.contains("ut.histo.p9999:0|g")) should be (true)
     } finally {
       exporter3.timer.stop()
     }


### PR DESCRIPTION
- A quick pull request to fix metric type for StatsdExporter. 
- location had some sensitive information when it comes to oAuth2; so trim all the query parameters