### PR TITLE
Move Endpoint and LoginManager config to example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.8-SNAPSHOT"
+lazy val Version = "0.2.9-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
@@ -136,6 +136,7 @@ case class SessionIdFilter(matcher: ServiceMatcher, store: SessionStore)(
   /**
    * Passes the SignedId to the next in the filter chain. If any failures decoding the SignedId occur
    * (expired, not there, etc), we will terminate early and send a redirect
+   *
    * @param req
    * @param service
    */
@@ -474,7 +475,8 @@ case class ExceptionFilter() extends SimpleFilter[Request, Response] {
     case error: BpUserError => logAndResponse(req, error.getMessage, error.status, Level.INFO)
     case error: BpCommunicationError => logAndResponse(req, error.getMessage, error.status, Level.WARNING)
     case error: BpCoreError => logAndResponse(req, error.getMessage, error.status, Level.INFO)
-    case error: Throwable => logAndResponse(req, error.getMessage, Status.InternalServerError, Level.WARNING)
+    case error: Throwable => logAndResponse(req, s"${error.getClass.getSimpleName}: ${error.getMessage}",
+      Status.InternalServerError, Level.WARNING)
   }
 
   def apply(req: Request, service: Service[Request, Response]): Future[Response] = {

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
@@ -400,6 +400,19 @@ class BorderAuthSpec extends BorderPatrolSuite {
     Await.result(output).status should be(Status.InternalServerError)
   }
 
+  it should "succeed and convert exception without a message into error Response" in {
+    case class NoMessageException(error: String) extends Throwable
+    val testService = Service.mk[Request, Response] { req =>
+      throw new NoMessageException("No message for Throwable")
+    }
+
+    // Execute
+    val output = (ExceptionFilter() andThen testService)(req("enterprise", "/ent"))
+
+    // Validate
+    Await.result(output).status should be(Status.InternalServerError)
+  }
+
   behavior of "SendToIdentityProvider"
 
   it should "send a request for unauth SessionId to loginConfirm path to IdentityService chain" in {


### PR DESCRIPTION
- it allows example to be innovative and create different objects
  for a given same base class of Endpoint and LoginManager
- also fixed handling Exception with noMessage (causes null pointer
  exception in LogFormatter)