### PR TITLE
Add action query param to request consent during AAD auth

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/tokenmaster/LoginManagers.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/tokenmaster/LoginManagers.scala
@@ -40,9 +40,13 @@ object LoginManagers {
 
     def redirectLocation(req: Request, params: Tuple2[String, String]*): String = {
       val hostStr = req.host.getOrElse(throw BpInvalidRequest(s"Host not found in HTTP $req"))
+      val prompt = req.params.get("action") match {
+        case Some(a) if a == "consent" => "admin_consent"
+        case _ => "login"
+      }
       val scheme = req.headerMap.getOrElse("X-Forwarded-Proto", "http")
       /* Send URL with query string */
-      val paramsMap = Map(("response_type", "code"), ("state", "foo"), ("prompt", "login"), ("client_id", clientId),
+      val paramsMap = Map(("response_type", "code"), ("state", "foo"), ("prompt", prompt), ("client_id", clientId),
         ("redirect_uri", s"$scheme://$hostStr$loginConfirm")) ++ params
       authorizeEndpoint.hosts.headOption.fold("")(_.toString) +
         Request.queryString(authorizeEndpoint.path.toString, paramsMap)

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/LoginManagersSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/LoginManagersSpec.scala
@@ -29,6 +29,8 @@ class LoginManagersSpec extends BorderPatrolSuite {
     val request1 = req("sky", "ulm1")
     request1.headerMap.set("X-Forwarded-Proto", "https")
     val request2 = req("sky", "ulm2")
+    val request3 = req("sky", "ulm3", "action" -> "consent")
+    val request4 = req("sky", "ulm4", "action" -> "foo")
     val location1 = umbrellaLoginManager.redirectLocation(request1)
     val location2 = umbrellaLoginManager.redirectLocation(request2, "foo" -> "bar", "bar" -> "baz")
     location1 should startWith(umbrellaLoginManager.authorizeEndpoint.hosts.head.toString +
@@ -41,6 +43,8 @@ class LoginManagersSpec extends BorderPatrolSuite {
     location2 should include("redirect_uri=http%3A%2F%2Fsky.example.com%2Fsignin")
     location2 should include("foo=bar")
     location2 should include("bar=baz")
+    umbrellaLoginManager.redirectLocation(request3) should include("prompt=admin_consent")
+    umbrellaLoginManager.redirectLocation(request4) should include("prompt=login")
   }
 
   it should "succeed to fetch oAuth2 token for code from server" in {

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.11-SNAPSHOT"
+lazy val Version = "0.2.12-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",


### PR DESCRIPTION
If `action=consent`, then AAD redirect contains `prompt=admin_consent`. This is typically necessary, when AAD admin provides access to apps for AAD non admins