### PR TITLE
Disable failfast if single host is configured on a endpoint

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.13-SNAPSHOT"
+lazy val Version = "0.2.14-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",
@@ -28,7 +28,7 @@ lazy val compilerOptions = Seq(
 lazy val finagleVersion = "6.35.0"
 lazy val circeVersion = "0.4.0"
 lazy val twitterServerVersion = "1.20.0"
-lazy val nimbusVersion = "4.15"
+lazy val nimbusVersion = "4.7"
 
 val testDependencies = Seq(
   "org.scalacheck" %% "scalacheck" % "1.13.0",

--- a/core/src/test/scala/com/lookout/borderpatrol/test/EndpointSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/EndpointSpec.scala
@@ -21,7 +21,7 @@ class EndpointSpec extends BorderPatrolSuite {
     }
   }
 
-  behavior of "Config"
+  behavior of "Endpoint"
 
   it should "store clients in the cache" in {
     val server = com.twitter.finagle.Http.serve(

--- a/core/src/test/scala/com/lookout/borderpatrol/test/EndpointSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/EndpointSpec.scala
@@ -3,7 +3,7 @@ package com.lookout.borderpatrol.test
 import java.net.URL
 
 import com.lookout.borderpatrol._
-import com.twitter.finagle.Service
+import com.twitter.finagle.{Http, Service}
 import com.twitter.finagle.http.path.Path
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.util.Await
@@ -50,5 +50,10 @@ class EndpointSpec extends BorderPatrolSuite {
     } finally {
       server.close()
     }
+  }
+
+  it should "ensure tls and failfast codepath executions" in {
+    Endpoint.failFast(tokenmasterIdEndpoint)(Http.client)
+    Endpoint.tls(tokenmasterIdEndpoint)(Http.client)
   }
 }


### PR DESCRIPTION
In such scenarios, we typically assume that single host is going to be ELB.
Also restored nimbus version back to 4.7 for compatibility.