### PR TITLE
On user error, redirect with error code instead of error message as query param

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/tokenmaster/Tokenmaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/tokenmaster/Tokenmaster.scala
@@ -168,9 +168,8 @@ object Tokenmaster {
         case Return(resp) => resp.toFuture
         case Throw(e: BpUserError) =>
           BorderAuth.formatRedirectResponse(req.req, e.status,
-            req.customerId.loginManager.redirectLocation(req.req,
-              ("msg" -> "Failed to authenticate the user, please check your credentials")), None,
-            e.getMessage + ", redirecting back to login page").toFuture
+            req.customerId.loginManager.redirectLocation(req.req, ("errorCode" -> Status.BadRequest.code.toString)),
+            None, e.getMessage + ", redirecting back to login page").toFuture
         case Throw(e: Throwable) => e.toFutureException
       }
     }

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/TokenmasterSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/TokenmasterSpec.scala
@@ -254,8 +254,7 @@ class TokenmasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Validate
     Await.result(output).status should be(Status.Found)
-    Await.result(output).location.get should
-      include("msg=Failed%20to%20authenticate%20the%20user%2C%20please%20check%20your%20credentials")
+    Await.result(output).location.get should include("errorCode=400")
   }
 
   it should "propagate BpIdentityProviderError thrown by service" in {

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.16-SNAPSHOT"
+lazy val Version = "0.2.17-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/Identity.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/Identity.scala
@@ -1,7 +1,5 @@
 package com.lookout.borderpatrol.auth
 
-import com.twitter.finagle.Service
-
 /**
  * The purpose of this abstraction to return some input from a user or entity that can be transformed into an
  * understandable identity to be used in the `AccessRequest`. There is no requirement that the identity from the


### PR DESCRIPTION
When user login fails due to user error, then user is redirected back to login page. Currently, the redirect location contains query param to indicate failure message. Intent of this fix is to change this error message to a http status code