### PR TITLE
Added loggedOutUrl for a landing page after a logout

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/tokenmaster/LoginManagers.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/tokenmaster/LoginManagers.scala
@@ -1,5 +1,7 @@
 package com.lookout.borderpatrol.auth.tokenmaster
 
+import java.net.URL
+
 import com.lookout.borderpatrol.auth.{BorderRequest, BpInvalidRequest, SessionIdRequest}
 import com.lookout.borderpatrol.sessionx.Session
 import com.lookout.borderpatrol.{Endpoint, LoginManager}
@@ -41,14 +43,15 @@ object LoginManagers {
 
     def redirectLocation(req: Request, params: Tuple2[String, String]*): String = {
       val hostStr = req.host.getOrElse(throw BpInvalidRequest(s"Host not found in HTTP $req"))
-      val prompt = req.params.get("action") match {
-        case Some(a) if a == "consent" => "admin_consent"
-        case _ => "login"
-      }
       val scheme = req.headerMap.getOrElse("X-Forwarded-Proto", "http")
+      val prompt = req.params.get("action") match {
+        case Some(a) if a == "consent" => Map("prompt" -> "admin_consent")
+        case _ => Map.empty[String, String]
+      }
       /* Send URL with query string */
-      val paramsMap = Map(("response_type", "code"), ("state", "foo"), ("prompt", prompt), ("client_id", clientId),
-        ("redirect_uri", s"$scheme://$hostStr$loginConfirm")) ++ params
+      val paramsMap = Map(("response_type", "code"), ("state", "foo"), ("client_id", clientId),
+        ("redirect_uri", s"$scheme://$hostStr$loginConfirm")) ++ params ++ prompt
+
       authorizeEndpoint.hosts.headOption.fold("")(_.toString) +
         Request.queryString(authorizeEndpoint.path.toString, paramsMap)
     }
@@ -78,12 +81,13 @@ object LoginManagers {
    * @param name name of the login manager
    * @param guid
    * @param loginConfirm path owned by borderpatrol. The interal login form POSTs here
+   * @param loggedOutUrl destination after the logout
    * @param authorizePath path of the internal login form
    * @param identityEndpoint endpoint that does identity provisioning for the cloud
    * @param accessEndpoint endpoint that does access issuing for the cloud
    */
-  case class BasicLoginManager(name: String, tyfe: String, guid: String, loginConfirm: Path, authorizePath: Path,
-                               identityEndpoint: Endpoint, accessEndpoint: Endpoint)
+  case class BasicLoginManager(name: String, tyfe: String, guid: String, loginConfirm: Path, loggedOutUrl: Option[URL],
+                               authorizePath: Path, identityEndpoint: Endpoint, accessEndpoint: Endpoint)
       extends LoginManager with BasicAuthLoginManagerMixin
 
   /**
@@ -92,6 +96,7 @@ object LoginManagers {
    * @param name name of the login manager
    * @param guid
    * @param loginConfirm path owned by borderpatrol. The OAuth2 server posts the oAuth2 code on this path
+   * @param loggedOutUrl destination after the logout
    * @param identityEndpoint endpoint that does identity provisioning for the cloud
    * @param accessEndpoint endpoint that does access issuing for the cloud
    * @param authorizeEndpoint External endpoint of the OAuth2 service where client is redirected for authentication
@@ -100,9 +105,9 @@ object LoginManagers {
    * @param clientId Id used for communicating with OAuth2 server
    * @param clientSecret Secret used for communicating with OAuth2 server
    */
-  case class OAuth2LoginManager(name: String, tyfe: String, guid: String, loginConfirm: Path,
-                                identityEndpoint: Endpoint, accessEndpoint: Endpoint,
-                                authorizeEndpoint: Endpoint, tokenEndpoint: Endpoint, certificateEndpoint: Endpoint,
+  case class OAuth2LoginManager(name: String, tyfe: String, guid: String, loginConfirm: Path, loggedOutUrl: Option[URL],
+                                identityEndpoint: Endpoint, accessEndpoint: Endpoint, authorizeEndpoint: Endpoint,
+                                tokenEndpoint: Endpoint, certificateEndpoint: Endpoint,
                                 clientId: String, clientSecret: String)
       extends LoginManager with OAuth2LoginManagerMixin
 }

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/LoginManagersSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/LoginManagersSpec.scala
@@ -38,14 +38,14 @@ class LoginManagersSpec extends BorderPatrolSuite {
       umbrellaLoginManager.authorizeEndpoint.path.toString)
     location1 should include("response_type=code")
     location1 should include("state=foo")
-    location1 should include("prompt=login")
+    location1 should not include("prompt=")
     location1 should include("client_id=clientId")
     location1 should include("redirect_uri=https%3A%2F%2Fsky.example.com%2Fsignin")
     location2 should include("redirect_uri=http%3A%2F%2Fsky.example.com%2Fsignin")
     location2 should include("foo=bar")
     location2 should include("bar=baz")
     umbrellaLoginManager.redirectLocation(request3) should include("prompt=admin_consent")
-    umbrellaLoginManager.redirectLocation(request4) should include("prompt=login")
+    umbrellaLoginManager.redirectLocation(request4) should not include("prompt=")
   }
 
   it should "succeed to fetch oAuth2 token for code from server" in {

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/tokenmasterTestHelpers.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/tokenmasterTestHelpers.scala
@@ -30,13 +30,13 @@ object tokenmasterTestHelpers {
 
   // Login Managers
   val checkpointLoginManager = BasicLoginManager("checkpointLoginManager", "tokenmaster.basic", "cp-guid",
-    Path("/loginConfirm"), Path("/check"), tokenmasterIdEndpoint, tokenmasterAccessEndpoint)
+    Path("/loginConfirm"), None, Path("/check"), tokenmasterIdEndpoint, tokenmasterAccessEndpoint)
   val umbrellaLoginManager = OAuth2LoginManager("ulmLoginManager", "tokenmaster.oauth2", "ulm-guid", Path("/signin"),
-    tokenmasterIdEndpoint, tokenmasterAccessEndpoint,
+    Some(new URL("http://www.example.com")), tokenmasterIdEndpoint, tokenmasterAccessEndpoint,
     ulmAuthorizeEndpoint, ulmTokenEndpoint, ulmCertificateEndpoint,
     "clientId", "clientSecret")
   val rainyLoginManager = OAuth2LoginManager("rlmProtoManager", "tokenmaster.oauth2", "rlm-guid", Path("/signblew"),
-    tokenmasterIdEndpoint, tokenmasterAccessEndpoint,
+    Some(new URL("http://www.example.com")), tokenmasterIdEndpoint, tokenmasterAccessEndpoint,
     rlmAuthorizeEndpoint, rlmTokenEndpoint, rlmCertificateEndpoint,
     "clientId", "clientSecret")
   val loginManagersk = Set(checkpointLoginManager.asInstanceOf[LoginManager],

--- a/bpConfig.json
+++ b/bpConfig.json
@@ -58,6 +58,7 @@
       "type": "tokenmaster.oauth2",
       "guid": "1111-1111-22222222",
       "loginConfirm": "/signin",
+      "loggedOutUrl": "http://www.example.com",
       "identityEndpoint": "tokenmaster-identity-example",
       "accessEndpoint": "tokenmaster-access-example",
       "authorizeEndpoint": "aad-authorize-example",

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.18-SNAPSHOT"
+lazy val Version = "0.2.19-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/LoginManager.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/LoginManager.scala
@@ -1,5 +1,7 @@
 package com.lookout.borderpatrol
 
+import java.net.URL
+
 import com.twitter.finagle.http.Request
 import com.twitter.finagle.http.path.Path
 
@@ -14,6 +16,7 @@ trait LoginManager {
   val tyfe: String
   val guid: String
   val loginConfirm: Path
+  val loggedOutUrl: Option[URL]
   val identityEndpoint: Endpoint
   val accessEndpoint: Endpoint
   def redirectLocation(req: Request, params: Tuple2[String, String]*): String

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
@@ -1078,9 +1078,9 @@ class BorderAuthSpec extends BorderPatrolSuite {
     Await.result(output).cookies.get(SignedId.sessionIdCookieName) should be (None)
   }
 
-  it should "succeed to logout the requests w/o sessionId w/ JSON response to logged out page" in {
+  it should "succeed to logout the requests w/o sessionId w/ JSON response to destination in query param" in {
     // Create request
-    val request = req("sky", "/logout", ("destination", "/abc%0d%0atest:abc%0d%0a"))
+    val request = req("enterprise", "/logout", ("destination", "/abc"))
     request.accept = Seq("application/json")
 
     // Execute
@@ -1090,7 +1090,23 @@ class BorderAuthSpec extends BorderPatrolSuite {
     // Validate
     Await.result(output).status should be (Status.Ok)
     Await.result(output).contentType.get should include("application/json")
-    Await.result(output).contentString should include(s""""redirect_url" : "/abc%0d%0atest:abc%0d%0a"""")
+    Await.result(output).contentString should include(s""""redirect_url" : "/abc"""")
+    Await.result(output).cookies.get(SignedId.sessionIdCookieName) should be (None)
+  }
+
+  it should "succeed to logout the requests w/o sessionId w/ JSON response to loggedOut URL" in {
+    // Create request
+    val request = req("sky", "/logout", ("destination", "/abc"))
+    request.accept = Seq("application/json")
+
+    // Execute
+    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen LogoutService(sessionStore))(
+      request)
+
+    // Validate
+    Await.result(output).status should be (Status.Ok)
+    Await.result(output).contentType.get should include("application/json")
+    Await.result(output).contentString should include(s""""redirect_url" : "http://www.example.com"""")
     Await.result(output).cookies.get(SignedId.sessionIdCookieName) should be (None)
   }
 }

--- a/core/src/test/scala/com/lookout/borderpatrol/test/coreTestHelpers.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/coreTestHelpers.scala
@@ -65,6 +65,7 @@ object coreTestHelpers {
     val tyfe: String = "test1.type"
     val guid: String = "test1.guid"
     val loginConfirm: Path = Path("/test1/confirm")
+    val loggedOutUrl: Option[URL] = None
     val identityEndpoint: Endpoint = tokenmasterIdEndpoint
     val accessEndpoint: Endpoint = tokenmasterAccessEndpoint
     def redirectLocation(req: Request, params: Tuple2[String, String]*): String = "/test1/redirect"
@@ -74,6 +75,7 @@ object coreTestHelpers {
     val tyfe: String = "test2.type"
     val guid: String = "test2.guid"
     val loginConfirm: Path = Path("/test2/confirm")
+    val loggedOutUrl: Option[URL] = Some(new URL("http://www.example.com"))
     val identityEndpoint: Endpoint = tokenmasterIdEndpoint
     val accessEndpoint: Endpoint = tokenmasterAccessEndpoint
     def redirectLocation(req: Request, params: Tuple2[String, String]*): String = "/test2/redirect"

--- a/example/src/main/scala/com/lookout/borderpatrol/example/ServerConfig.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/ServerConfig.scala
@@ -78,6 +78,7 @@ object ServerConfig {
       ("type", blm.tyfe.asJson),
       ("guid", blm.guid.asJson),
       ("loginConfirm", blm.loginConfirm.asJson),
+      ("loggedOutUrl", blm.loggedOutUrl.asJson),
       ("authorizePath", blm.authorizePath.asJson),
       ("identityEndpoint", blm.identityEndpoint.name.asJson),
       ("accessEndpoint", blm.accessEndpoint.name.asJson)
@@ -89,6 +90,7 @@ object ServerConfig {
       ("type", olm.tyfe.asJson),
       ("guid", olm.guid.asJson),
       ("loginConfirm", olm.loginConfirm.asJson),
+      ("loggedOutUrl", olm.loggedOutUrl.asJson),
       ("identityEndpoint", olm.identityEndpoint.name.asJson),
       ("accessEndpoint", olm.accessEndpoint.name.asJson),
       ("authorizeEndpoint", olm.authorizeEndpoint.name.asJson),
@@ -111,12 +113,13 @@ object ServerConfig {
       tyfe <- c.downField("type").as[String]
       guid <- c.downField("guid").as[String]
       loginConfirm <- c.downField("loginConfirm").as[Path]
+      loggedOutUrl <- c.downField("loggedOutUrl").as[Option[URL]]
       authorizePath <- c.downField("authorizePath").as[Path]
       ieName <- c.downField("identityEndpoint").as[String]
       ie <- Xor.fromOption(eps.get(ieName), DecodingFailure(s"identityEndpoint '$ieName' not found: ", c.history))
       aeName <- c.downField("accessEndpoint").as[String]
       ae <- Xor.fromOption(eps.get(aeName), DecodingFailure(s"accessEndpoint '$aeName' not found: ", c.history))
-    } yield BasicLoginManager(name, tyfe, guid, loginConfirm, authorizePath,
+    } yield BasicLoginManager(name, tyfe, guid, loginConfirm, loggedOutUrl, authorizePath,
       ie.toSimpleEndpoint, ae.toSimpleEndpoint)
   }
   def decodeOAuth2LoginManager(eps: Map[String, EndpointConfig]): Decoder[OAuth2LoginManager] = Decoder.instance { c =>
@@ -125,6 +128,7 @@ object ServerConfig {
       tyfe <- c.downField("type").as[String]
       guid <- c.downField("guid").as[String]
       loginConfirm <- c.downField("loginConfirm").as[Path]
+      loggedOutUrl <- c.downField("loggedOutUrl").as[Option[URL]]
       ieName <- c.downField("identityEndpoint").as[String]
       ie <- Xor.fromOption(eps.get(ieName), DecodingFailure(s"identityEndpoint '$ieName' not found: ", c.history))
       aeName <- c.downField("accessEndpoint").as[String]
@@ -138,7 +142,7 @@ object ServerConfig {
         DecodingFailure(s"certificateEndpoint '$ceName' not found: ", c.history))
       clientId <- c.downField("clientId").as[String]
       clientSecret <- c.downField("clientSecret").as[String]
-    } yield OAuth2LoginManager(name, tyfe, guid, loginConfirm,
+    } yield OAuth2LoginManager(name, tyfe, guid, loginConfirm, loggedOutUrl,
       ie.toSimpleEndpoint, ae.toSimpleEndpoint, au.toSimpleEndpoint, te.toSimpleEndpoint, ce.toSimpleEndpoint,
       clientId, clientSecret)
   }

--- a/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
@@ -149,7 +149,7 @@ class ConfigSpec extends BorderPatrolSuite {
 
   it should "return a Set with errors if duplicates are configured in loginManagers config" in {
     val output = validateLoginManagerConfig("loginManagers", loginManagersk +
-      BasicLoginManager("checkpointLoginManager", "tokenmaster-basic", "some-guid", Path("/some"), Path("/some"),
+      BasicLoginManager("checkpointLoginManager", "tokenmaster-basic", "some-guid", Path("/some"), None, Path("/some"),
         tokenmasterIdEndpoint, tokenmasterAccessEndpoint))
     output should contain ("Duplicate entries for key (name) are found in the field: loginManagers")
   }


### PR DESCRIPTION
* The landing page can be added to login manager config
* Its an optional
* If configured, after logout, user will be redirected to `loggedOutUrl`. If not configured, after logout, user is redirected to `destination` query param or defaultService path configured on the subdomain.