### PR TITLE
Re-route forbidden requests to Borderpatrol

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/tokenmaster/Tokenmaster.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/tokenmaster/Tokenmaster.scala
@@ -160,7 +160,8 @@ object Tokenmaster {
         statSessionAuthenticated.incr
         BorderAuth.formatRedirectResponse(req.req, Status.Ok, originReq.uri, Some(session.id),
           s"SessionId: ${req.sessionId.toLogIdString}} is authenticated, " +
-            s"allocated new SessionId: ${session.id.toLogIdString} and redirecting to " +
+            s"allocated new SessionId: ${session.id.toLogIdString}, " +
+            s"IPAddress: ${req.req.xForwardedFor.getOrElse("No IP Address")} and redirecting to " +
             s"location: ${originReq.path}")
       })
         /** Capture User error here, log it and redirect user back to login page */

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/TokenmasterSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/TokenmasterSpec.scala
@@ -630,8 +630,7 @@ class TokenmasterSpec extends BorderPatrolSuite with MockitoSugar {
       val caught = the[BpForbiddenRequest] thrownBy {
         Await.result(output)
       }
-      caught.getMessage should include("Forbidden: Failed to permit access to the service: 'one'")
-      caught.status should be(Status.Forbidden)
+      caught.getMessage should include(s"Forbidden: Failed to permit access to the service: 'one'")
     } finally {
       server.close()
     }

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.19-SNAPSHOT"
+lazy val Version = "0.2.20-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
@@ -500,6 +500,7 @@ case class ExceptionFilter() extends SimpleFilter[Request, Response] {
     case error: BpUserError => logAndResponse(req, error.getMessage, error.status, Level.INFO)
     case error: BpCommunicationError => logAndResponse(req, error.getMessage, error.status, Level.WARNING)
     case error: BpCoreError => logAndResponse(req, error.getMessage, error.status, Level.INFO)
+    case error: BpForbiddenRequest => logAndResponse(req, error.getMessage, Status.Forbidden, Level.INFO)
     case error: Throwable => logAndResponse(req, s"${error.getClass.getSimpleName}: ${error.getMessage}",
       Status.InternalServerError, Level.WARNING)
   }

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/Errors.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/Errors.scala
@@ -15,9 +15,14 @@ case class BpTokenParsingError(msg: String)
 case class BpCertificateError(msg: String)
   extends BpAuthError(s"Failed to process Certificate with: $msg}")
 
-case class BpIdentityProviderError(msg: String) extends BpAuthError(s"Failed in identity provisioning with: $msg}")
+case class BpIdentityProviderError(msg: String)
+  extends BpAuthError(s"Failed in identity provisioning with: $msg}")
 
-case class BpAccessIssuerError(msg: String) extends BpAuthError(s"Failed in access issuer with: $msg}")
+case class BpAccessIssuerError(msg: String)
+  extends BpAuthError(s"Failed in access issuer with: $msg}")
+
+case class BpForbiddenRequest(msg: String = "")
+  extends BpAuthError(s"${Status.Forbidden.reason}: $msg")
 
 /**
   * User initiated error(s) - encoutered during identity or access phase
@@ -32,9 +37,6 @@ case class BpTokenAccessError(msg: String)
 
 case class BpVerifyTokenError(msg: String)
   extends BpUserError(Status.BadRequest, s"Failed to verify the signature on the token: $msg}")
-
-case class BpForbiddenRequest(msg: String = "")
-  extends BpUserError(Status.Forbidden, s"${Status.Forbidden.reason}: $msg")
 
 case class BpUnauthorizedRequest(msg: String = "")
   extends BpUserError(Status.Unauthorized, s"${Status.Unauthorized.reason}: $msg")

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
@@ -401,6 +401,19 @@ class BorderAuthSpec extends BorderPatrolSuite {
     Await.result(output).status should be(Status.InternalServerError)
   }
 
+  it should "succeed and convert the BpForbiddenRequest exception into error Response" in {
+    val testService = Service.mk[Request, Response] { req =>
+      Future.exception(BpForbiddenRequest("Some identity provider error"))
+    }
+
+    // Execute
+    val output = (ExceptionFilter() andThen testService)(req("enterprise", "/ent"))
+
+    // Validate
+    Await.result(output).status should be(Status.Forbidden)
+    Await.result(output).contentString should be("Oops, something went wrong, please try your action again")
+  }
+
   it should "succeed and convert exception without a message into error Response" in {
     case class NoMessageException(error: String) extends Throwable
     val testService = Service.mk[Request, Response] { req =>


### PR DESCRIPTION
Forbidden requests to Borderpatrol to be routed to forbidden page instead of login page.