### PR TITLE
Fix memcached client config. Enable evict and setup failure accrual policy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.22-SNAPSHOT"
+lazy val Version = "0.2.23-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",


### PR DESCRIPTION
The main intention of this fix is to ensure that when a node from the list goes down (as determined by FailureAccrualPolicy), the node is removed from the list, so that failures can be contained. The node is marked dead for 60 seconds. After that timeout, the node will start probing. If down, we may experience additional failure, but node will be again marked as dead. However, if node is up, the probing will succeed and node will be back into the service. 

