### PR TITLE
Fix mock services to handle content in json format

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.25-SNAPSHOT"
+lazy val Version = "0.2.26-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
@@ -54,7 +54,7 @@ object BorderAuth {
 
   /* Convert a redirect into a response palatable to the client */
   def formatRedirectResponse(req: Request, status: Status, location: String, sessionIdOpt: Option[SignedId],
-                             msg: String): Response = {
+                             msg: String, msgSrc: String = "borderpatrol"): Response = {
     log.info(msg)
     tap(Response())(res => {
       sessionIdOpt.foreach(sessionId => res.addCookie(sessionId.asCookie()))
@@ -62,7 +62,7 @@ object BorderAuth {
         case true =>
           res.status = status
           res.contentString = Json.fromFields(Seq(
-            ("msg_source", "borderpatrol".asJson),
+            ("msg_source", msgSrc.asJson),
             ("redirect_url", location.asJson))).toString()
           res.setContentTypeJson()
         case _ =>


### PR DESCRIPTION
Update the mock to process the json content. Also, updated the formatRedirectResponse code to take `msgSrc` as an optional input