### PR TITLE
Move canned response to a val and bump up version

### DIFF
--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/TokenmasterSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/TokenmasterSpec.scala
@@ -155,7 +155,7 @@ class TokenmasterSpec extends BorderPatrolSuite with MockitoSugar {
     Await.result(tokensz) should be(tokens)
   }
 
-  it should "throw BpOriginalRequestNotFound and redirect to login on failure to lookup req from sessionStore" in {
+  it should "redirect to default service on failure to lookup original req from sessionStore" in {
     val testService = Service.mk[BorderRequest, IdentifyResponse[Tokens]] {
       req => Future(TokenmasterIdentifyRes(tokens)) }
 
@@ -171,7 +171,7 @@ class TokenmasterSpec extends BorderPatrolSuite with MockitoSugar {
 
     // Validate
     Await.result(output).status should be(Status.Found)
-    Await.result(output).location.get should include("errorCode=400")
+    Await.result(output).location.get should include("/ent")
   }
 
   it should "throw Exception if Session lookup operation throws an exception" in {

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.27-SNAPSHOT"
+lazy val Version = "0.2.28-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/Errors.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/Errors.scala
@@ -44,6 +44,3 @@ case class BpUnauthorizedRequest(msg: String = "")
 case class BpInvalidRequest(msg: String = "")
   extends BpUserError(Status.BadRequest, s"${Status.BadRequest.reason}: $msg")
 
-case class BpOriginalRequestNotFound(msg: String)
-  extends BpUserError(Status.BadRequest ,s"Failed to lookup request from the session store: $msg")
-

--- a/security/src/main/scala/com/lookout/borderpatrol/security/HostHeaderFilter.scala
+++ b/security/src/main/scala/com/lookout/borderpatrol/security/HostHeaderFilter.scala
@@ -5,7 +5,7 @@ import com.lookout.borderpatrol.util.Combinators.tap
 import com.twitter.finagle.util.InetSocketAddressUtil
 import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.finagle.http.{Status, Response, Request}
-import com.twitter.logging.{Level, Logger}
+import com.twitter.logging.Logger
 import com.twitter.util.Future
 import scala.util.Try
 
@@ -18,38 +18,11 @@ import scala.util.Try
   * @param validHosts
   */
 case class HostHeaderFilter(validHosts: Set[InternetDomainName]) extends SimpleFilter[Request, Response] {
-
-  lazy val validHostStrings = validHosts.map( validHost => validHost.toString )
+  lazy val validHostStrings = validHosts.map(_.toString)
   private[this] val log = Logger.get(getClass.getPackage.getName)
 
-  /**
-    * Attempt to return the hostname by stripping out the port portion including
-    * the semicolon from the provided host entry.
-    *
-    * @param host
-    * @return
-    */
-  private[security] def extractHostName(host: String): String = {
-    Try (InetSocketAddressUtil.parseHostPorts(host).head._1).getOrElse(host)
-  }
-
-  /**
-    * Requests get forwarded to service only for host entries that have been assigned to this filter
-    */
-  def apply(request: Request, service: Service[Request, Response]): Future[Response] = {
-    request.host.map( extractHostName(_)) match {
-      case None =>
-        log.log(Level.WARNING, "Host Header: is empty")
-        cannedResponse
-      case Some(hostName) if (!validHostStrings(hostName)) =>
-        log.log(Level.WARNING, s"Host Header: '${hostName}' not found")
-        cannedResponse
-      case _ => service(request)
-    }
-  }
-
-  private[this] def cannedResponse(): Future[Response] = {
-    Future.value(tap(Response(Status.BadRequest))(res => {
+  private[this] val cannedResponse: Response = {
+    tap(Response(Status.BadRequest))(res => {
       res.contentString =
         """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
           |<HTML><HEAD><TITLE>Bad Request</TITLE>
@@ -59,6 +32,27 @@ case class HostHeaderFilter(validHosts: Set[InternetDomainName]) extends SimpleF
           |</BODY></HTML>
           |* Closing connect""".stripMargin
       res.contentType = "text/html; charset=us-ascii"
-    }))
+    })
+  }
+
+  /**
+    * Attempt to return the hostname by stripping out the port portion including
+    * the semicolon from the provided host entry.
+    *
+    * @param host
+    * @return
+    */
+  def extractHostName(host: String): String = {
+    Try (InetSocketAddressUtil.parseHostPorts(host).head._1).getOrElse(host)
+  }
+
+  /**
+    * Requests get forwarded to service only for host entries that have been assigned to this filter
+    */
+  def apply(request: Request, service: Service[Request, Response]): Future[Response] = {
+    request.host.map(extractHostName(_)) match {
+      case Some(hostName) if validHostStrings.contains(hostName) => service(request)
+      case _ => Future.value(cannedResponse)
+    }
   }
 }

--- a/security/src/test/scala/com/lookout/borderpatrol/test/security/HostHeaderFilterSpec.scala
+++ b/security/src/test/scala/com/lookout/borderpatrol/test/security/HostHeaderFilterSpec.scala
@@ -1,12 +1,11 @@
-package com.lookout.borderpatrol.security
+package com.lookout.borderpatrol.test.security
 
 import com.google.common.net.InternetDomainName
+import com.lookout.borderpatrol.security.HostHeaderFilter
 import com.lookout.borderpatrol.test._
 import com.twitter.finagle.http.{Request, Status}
 import com.twitter.finagle.util.InetSocketAddressUtil
 import com.twitter.util.Await
-
-import scala.util.{Failure, Success, Try}
 
 /**
   * Created by rikesh.chouhan on 7/19/16.

--- a/security/src/test/scala/com/lookout/borderpatrol/test/security/HostHeaderFilterSpec.scala
+++ b/security/src/test/scala/com/lookout/borderpatrol/test/security/HostHeaderFilterSpec.scala
@@ -11,8 +11,10 @@ import com.twitter.util.Await
   * Created by rikesh.chouhan on 7/19/16.
   */
 class HostHeaderFilterSpec extends BorderPatrolSuite {
+  import coreTestHelpers._
 
   behavior of "HostHeaderFilter"
+
   val validHostsString = Set("example.com","aad.example.com", "getouttahere.com")
   val validHosts = validHostsString map { host => InternetDomainName.from(host)}
   val checker = HostHeaderFilter(validHosts)


### PR DESCRIPTION
Resolve conflicts ensued by 180 and 181.

After successful authentication, if we fail to find that Original Request, then redirect user back to default service. That's a more resilient fix.