### PR TITLE
Add support for pushing CORS headers in response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ scala:
   - 2.11.8
 jdk:
   - oraclejdk8
+before_script: travis_retry sbt ++$TRAVIS_SCALA_VERSION update
 script: sbt ++$TRAVIS_SCALA_VERSION clean coverage test scalastyle && sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.28-SNAPSHOT"
+lazy val Version = "0.2.29-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
@@ -78,7 +78,7 @@ object service {
     val serviceMatcher = ServiceMatcher(config.customerIdentifiers, config.serviceIdentifiers)
     val notFoundService = Service.mk[SessionIdRequest, Response] { req => Response(Status.NotFound).toFuture }
     val serviceChainFront: Filter[Request, Response, Request, Response] =
-    /* Validate host if present to be present in pre-configured list*/
+      /* Validate host if present to be present in pre-configured list*/
       HostHeaderFilter(config.allowedDomains) andThen
       /* Convert exceptions to responses */
       ExceptionFilter()

--- a/security/src/test/scala/com/lookout/borderpatrol/test/security/SecureHeadersSpec.scala
+++ b/security/src/test/scala/com/lookout/borderpatrol/test/security/SecureHeadersSpec.scala
@@ -12,17 +12,15 @@ class SecureHeadersSpec extends BorderPatrolSuite {
 
   behavior of "SecureHeaderFilter"
   val requestDefaults = SecureHeaders.request
-  val defaults = SecureHeaders.response
   val validDomains = Set("www.yahoo.com", "www.google.com", "localhost")
-  implicit val allowedDomains: Set[InternetDomainName] = validDomains map (InternetDomainName.from(_))
-  val filter = SecureHeaderFilter(requestDefaults, defaults, allowedDomains)
+  val allowedDomains: Set[InternetDomainName] = validDomains map (InternetDomainName.from(_))
+  val defaults = SecureHeaders.response(allowedDomains)
+  val filter = SecureHeaderFilter(requestDefaults, allowedDomains)
   val service = filter andThen testService(r => true)
 
   it should "inject all of the headers" in {
     val request = Request("/")
-    val map: HeaderMap = service(request).results.headerMap
-    val catchFalse = defaults.map( m => map.contains(m._1)).collect { case false => 1}
-    catchFalse.size should be (0)
+    service(request).results.headerMap.sameElements(defaults) should be(true)
   }
 
   it should "append X-Forwarded-For to an existing list into request" in {

--- a/security/src/test/scala/com/lookout/borderpatrol/test/security/SecureHeadersSpec.scala
+++ b/security/src/test/scala/com/lookout/borderpatrol/test/security/SecureHeadersSpec.scala
@@ -1,22 +1,28 @@
 package com.lookout.borderpatrol.test.security
 
+import com.google.common.net.InternetDomainName
 import com.lookout.borderpatrol.security.SecureHeaderFilter
 import com.lookout.borderpatrol.security.SecureHeaders
 import com.lookout.borderpatrol.test._
 import com.twitter.finagle.Service
-import com.twitter.finagle.http.{Response, Request, Status}
+import com.twitter.finagle.http.{HeaderMap, Response, Request, Status}
 import com.twitter.util.Future
 
 class SecureHeadersSpec extends BorderPatrolSuite {
 
   behavior of "SecureHeaderFilter"
+  val requestDefaults = SecureHeaders.request
   val defaults = SecureHeaders.response
-  val filter = SecureHeaderFilter(defaults)
+  val validDomains = Set("www.yahoo.com", "www.google.com", "localhost")
+  implicit val allowedDomains: Set[InternetDomainName] = validDomains map (InternetDomainName.from(_))
+  val filter = SecureHeaderFilter(requestDefaults, defaults, allowedDomains)
   val service = filter andThen testService(r => true)
 
   it should "inject all of the headers" in {
     val request = Request("/")
-    service(request).results.headerMap.sameElements(defaults) should be(true)
+    val map: HeaderMap = service(request).results.headerMap
+    val catchFalse = defaults.map( m => map.contains(m._1)).collect { case false => 1}
+    catchFalse.size should be (0)
   }
 
   it should "append X-Forwarded-For to an existing list into request" in {
@@ -38,6 +44,14 @@ class SecureHeadersSpec extends BorderPatrolSuite {
     val response = Response(Status.Ok)
     response.headerMap.add("X-Download-Options", "arglebargle")
     val s = Service.mk[Request, Response](r => Future.value(response))
-    filter(request, s).results.headerMap.sameElements(defaults) should be(true)
+    filter(request, s).results.headerMap("X-Download-Options") should be(SecureHeaders.XDownloadOptions._2)
   }
+
+  it should "Find CORS Header with domains specified" in {
+    val request = Request("/")
+    val response = Response(Status.Ok)
+    val s = Service.mk[Request, Response](r => Future.value(response))
+    filter(request, s).results.headerMap(SecureHeaders.allowOrigin) should be(validDomains.mkString(","))
+  }
+
 }


### PR DESCRIPTION
Add CORS support. Update tests for specific expectations - such as overriding params in response and presence of CORS params in response.