### PR TITLE
Log and return 403, in case AAD returns anything other than oAuth2 code

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/tokenmaster/LoginManagers.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/tokenmaster/LoginManagers.scala
@@ -40,7 +40,7 @@ object LoginManagers {
     val clientSecret: String
 
     def redirectLocation(req: Request, params: Tuple2[String, String]*): String = {
-      val hostStr = req.host.getOrElse(throw BpInvalidRequest(s"Host not found in HTTP $req"))
+      val hostStr = req.host.getOrElse(throw BpInvalidRequest(s"Host not found in ${req}"))
       val scheme = req.headerMap.getOrElse("X-Forwarded-Proto", "http")
       val prompt = req.params.get("action") match {
         case Some(a) if a == "consent" => Map("prompt" -> "admin_consent")
@@ -55,7 +55,7 @@ object LoginManagers {
     }
 
     def codeToToken(req: BorderRequest): Future[Response] = {
-      val hostStr = req.req.host.getOrElse(throw BpInvalidRequest(s"Host not found in HTTP $req"))
+      val hostStr = req.req.host.getOrElse(throw BpInvalidRequest(s"Host not found in ${req.req}"))
       val scheme = req.req.headerMap.getOrElse("X-Forwarded-Proto", "http")
       val code = Helpers.scrubQueryParams(req.req.params, "code").fold {
         (Helpers.scrubQueryParams(req.req.params, "error"),

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/LoginManagersSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/LoginManagersSpec.scala
@@ -84,7 +84,7 @@ class LoginManagersSpec extends BorderPatrolSuite {
       // Execute
       val output = umbrellaLoginManager.redirectLocation(request)
     }
-    caught.getMessage should include("Host not found in HTTP Request")
+    caught.getMessage should include("Host not found in Request")
   }
 
   it should "throw a BpCommunicationError if it fails to reach OAuth2 IDP to convert code to token" in {
@@ -117,7 +117,7 @@ class LoginManagersSpec extends BorderPatrolSuite {
       // Execute
       val output = umbrellaLoginManager.codeToToken(borderRequest)
     }
-    caught.getMessage should include("Host not found in HTTP BorderRequest")
+    caught.getMessage should include("Host not found in Request")
   }
 
   it should "throw a BpForbiddenRequest if it fails to receive OAuth2 code from oAuth2 server" in {

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/LoginManagersSpec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/LoginManagersSpec.scala
@@ -1,17 +1,16 @@
 package com.lookout.borderpatrol.auth.tokenmaster
 
 import com.lookout.borderpatrol.BpCommunicationError
-import com.lookout.borderpatrol.auth.BorderRequest
+import com.lookout.borderpatrol.auth.{BorderRequest, BpForbiddenRequest}
 import com.lookout.borderpatrol.sessionx._
 import com.lookout.borderpatrol.test._
 import com.twitter.finagle.Service
-import com.twitter.finagle.http.{Status, Response, Request}
+import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.http.service.RoutingService
 import com.twitter.util.Await
 
 
 class LoginManagersSpec extends BorderPatrolSuite {
-
   import coreTestHelpers._
   import tokenmasterTestHelpers._
 
@@ -63,7 +62,7 @@ class LoginManagersSpec extends BorderPatrolSuite {
     try {
       // Login POST request
       val request = req("sky", "/signin", ("code" -> "XYZ123"))
-      val borderRequest = BorderRequest(request, cust1, one, sessionid.untagged)
+      val borderRequest = BorderRequest(request, cust2, two, sessionid.untagged)
       request.headerMap.set("X-Forwarded-Proto", "https")
 
       // Execute
@@ -95,7 +94,7 @@ class LoginManagersSpec extends BorderPatrolSuite {
 
     // Login POST request
     val request = req("rainy", "/signblew", ("code" -> "XYZ123"))
-    val borderRequest = BorderRequest(request, cust1, one, sessionid.untagged)
+    val borderRequest = BorderRequest(request, cust2, two, sessionid.untagged)
 
     // Execute
     val output = rainyLoginManager.codeToToken(borderRequest)
@@ -111,8 +110,7 @@ class LoginManagersSpec extends BorderPatrolSuite {
   it should "throw an Exception if host value is not present in the request when calling codeToToken" in {
     // Create request
     val request = Request("/umb")
-    val borderRequest = BorderRequest(request, cust1, one, sessionid.untagged)
-//    val borderRequest = BorderRequest(req("", "/umb", ("code" -> "XYZ123")), cust1, one, sessionid.untagged)
+    val borderRequest = BorderRequest(request, cust2, two, sessionid.untagged)
 
     // Validate
     val caught = the[Exception] thrownBy {
@@ -120,5 +118,39 @@ class LoginManagersSpec extends BorderPatrolSuite {
       val output = umbrellaLoginManager.codeToToken(borderRequest)
     }
     caught.getMessage should include("Host not found in HTTP BorderRequest")
+  }
+
+  it should "throw a BpForbiddenRequest if it fails to receive OAuth2 code from oAuth2 server" in {
+
+    // Allocate and Session
+    val sessionId = sessionid.untagged
+
+    // Login POST request
+    val request = req("enterprise", "/ent")
+    val borderRequest = BorderRequest(request, cust2, two, sessionid.untagged)
+
+    // Validate
+    val caught = the[BpForbiddenRequest] thrownBy {
+      // Execute
+      val output = umbrellaLoginManager.codeToToken(borderRequest)
+    }
+    caught.getMessage should include("Forbidden: OAuth2 code not found in HTTP Request")
+  }
+
+  it should "throw a BpForbiddenRequest and log error if it fails to receive OAuth2 code from oAuth2 server" in {
+
+    // Allocate and Session
+    val sessionId = sessionid.untagged
+
+    // Login POST request
+    val request = req("enterprise", "/ent", ("error" -> "Access_denied"), ("error_description" -> "Something bad"))
+    val borderRequest = BorderRequest(request, cust2, two, sessionid.untagged)
+
+    // Validate
+    val caught = the[BpForbiddenRequest] thrownBy {
+      // Execute
+      val output = umbrellaLoginManager.codeToToken(borderRequest)
+    }
+    caught.getMessage should include("OAuth2 authentication failed with error: 'Access_denied: Something bad'")
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.29-SNAPSHOT"
+lazy val Version = "0.2.30-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/util/Helpers.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/util/Helpers.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.http.ParamMap
 object Helpers {
 
   /** Regular Expression for all special characters from ASCII 0 to 32 */
-  private[this] val specialCharRegEx = (for (i <- 0 to 32) yield f"\\x$i%02x").mkString("[", "", "]")
+  private[this] val specialCharRegEx = (for (i <- 0 to 31) yield f"\\x$i%02x").mkString("[", "", "]")
 
   def scrubQueryParams(params: ParamMap, paramKey: String): Option[String] = {
     /* Lookup query param value for the given param key */
@@ -14,7 +14,7 @@ object Helpers {
       /* These param values could be malformed and may contain special characters. So lets scrub them out and
        * choose the first valid string as param
        */
-      l.split(specialCharRegEx).filterNot(_.isEmpty).headOption
+      l.split(specialCharRegEx).filterNot(_.isEmpty).headOption.map(_.trim)
     }
   }
 }

--- a/core/src/test/scala/com/lookout/borderpatrol/test/util/HelpersSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/util/HelpersSpec.scala
@@ -26,6 +26,8 @@ class HelpersSpec extends BorderPatrolSuite {
     scrubQueryParams(req3.params, "destination") should be(Some("/abc"))
     val req4 = Request("logout?destination=/%0d%0aabc%0d%0a")
     scrubQueryParams(req4.params, "destination") should be(Some("/"))
+    val req6 = Request("logout?destination=abc%20efg")
+    scrubQueryParams(req6.params, "destination") should be(Some("abc efg"))
 
     /* Error conditions */
     scrubQueryParams(req1.params, "foo") should be(None)

--- a/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
@@ -85,7 +85,8 @@ object service {
 
     RoutingService.byPath {
       case "/health" =>
-        serviceChainFront andThen
+        /* Convert exceptions to responses */
+        ExceptionFilter() andThen
           HealthCheckService(registry, BpBuild.BuildInfo.version)
 
       /** Logout */


### PR DESCRIPTION
- also allow "space" in the query param

Fixes #184