### PR TITLE
If destination query param is URL, then validate that host belongs to Set of valid hosts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.31-SNAPSHOT"
+lazy val Version = "0.2.32-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/BorderAuth.scala
@@ -397,11 +397,11 @@ case class LogoutService(store: SessionStore, destinationValidator: DestinationV
       log.debug(s"Logging out Session: ${sid.toLogIdString}")
       store.delete(sid)
     })
-    // Redirect to (1) the logged out url, (2) suggested url or (3) default service path, in that order
-    val location: String = (req.customerId.loginManager.loggedOutUrl,
-      BorderAuth.extractDestination(req.req.params)(destinationValidator)) match {
+    // Redirect to (1) suggested url or (2) the logged out url or (3) default service path, in that order
+    val location: String = (BorderAuth.extractDestination(req.req.params)(destinationValidator),
+      req.customerId.loginManager.loggedOutUrl) match {
       case (Some(loc), _) => loc.toString
-      case (None, Some(loc)) => loc
+      case (Some(loc),None) => loc
       case _ => {
         log.info("Could not determine host: "+req.req.params.get("destination")+" using default")
         req.customerId.defaultServiceId.path.toString
@@ -410,7 +410,6 @@ case class LogoutService(store: SessionStore, destinationValidator: DestinationV
     BorderAuth.formatLogoutResponse(req.req, Status.Ok, location,
       s"After logout, redirecting to: '$location'").toFuture
   }
-
 }
 
 /**

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/DestinationValidator.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/DestinationValidator.scala
@@ -1,0 +1,38 @@
+package com.lookout.borderpatrol.auth
+
+import java.net.URL
+
+import com.google.common.net.InternetDomainName
+
+import scala.util.{Success, Try}
+
+/**
+  * Created by rikesh.chouhan on 8/4/16.
+  */
+/**
+  * Placeholder for valid hosts name entries.
+  * It can determine whether or not an entry passed to it is contained in the valid hosts set.
+  *
+  * @param hostEntries
+  */
+case class DestinationValidator(hostEntries: Set[InternetDomainName]) {
+  lazy val validHosts: Set[String] = hostEntries.map(m => m.toString)
+
+  /**
+    * Attempt to check whether this is a valid host entry.
+    * If yes - return it wrapped as Option
+    * If no -
+    *   Is this a URL
+    *   Yes - Attempt to get host and find if it is a valid host entry
+    *   No - (could be relative path) return the fragment as is
+    *
+    * @param location (could be a URL - if yes attempt to extract host from entry and use that for match)
+    * @return
+    */
+  def matchesValidHosts(location: String): Option[String] =
+    Try(new URL(location)) match {
+      case Success(s) if (!validHosts.contains(s.getHost)) => None
+      case _ => Some(location)
+    }
+
+}

--- a/core/src/main/scala/com/lookout/borderpatrol/auth/DestinationValidator.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/auth/DestinationValidator.scala
@@ -29,8 +29,8 @@ case class DestinationValidator(hostEntries: Set[InternetDomainName]) {
     * @param location (could be a URL - if yes attempt to extract host from entry and use that for match)
     * @return
     */
-  def matchesValidHosts(location: String): Option[String] =
-    Try(new URL(location)) match {
+  def checkHosts(location: String): Option[String] =
+    Try (new URL(location)) match {
       case Success(s) if (!validHosts.contains(s.getHost)) => None
       case _ => Some(location)
     }

--- a/core/src/main/scala/com/lookout/borderpatrol/util/Helpers.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/util/Helpers.scala
@@ -8,16 +8,25 @@ object Helpers {
   /** Regular Expression for all special characters from ASCII 0 to 32 */
   private[this] val specialCharRegEx = (for (i <- 0 to 31) yield f"\\x$i%02x").mkString("[", "", "]")
 
+  /**
+    * Lookup query param value for the given param key.
+    * These param values could be malformed and may contain special characters. So lets scrub them out and
+    * choose the first valid string as param
+    * @param params - the map
+    * @param paramKey - specific key to get look for and get first valid value
+    * @return scrubbed value
+    */
   def scrubQueryParams(params: ParamMap, paramKey: String): Option[String] = {
-    /* Lookup query param value for the given param key */
     params.get(paramKey).flatMap { l =>
-      /* These param values could be malformed and may contain special characters. So lets scrub them out and
-       * choose the first valid string as param
-       */
       scrubAString(l)
     }
   }
 
+  /**
+    * Scrub a string passed in and return value
+    * @param toScrub
+    * @return
+    */
   def scrubAString(toScrub: String): Option[String] = {
     toScrub.split(specialCharRegEx).filterNot(_.isEmpty).headOption.map(_.trim)
   }

--- a/core/src/main/scala/com/lookout/borderpatrol/util/Helpers.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/util/Helpers.scala
@@ -14,7 +14,11 @@ object Helpers {
       /* These param values could be malformed and may contain special characters. So lets scrub them out and
        * choose the first valid string as param
        */
-      l.split(specialCharRegEx).filterNot(_.isEmpty).headOption.map(_.trim)
+      scrubAString(l)
     }
+  }
+
+  def scrubAString(toScrub: String): Option[String] = {
+    toScrub.split(specialCharRegEx).filterNot(_.isEmpty).headOption.map(_.trim)
   }
 }

--- a/core/src/main/scala/com/lookout/borderpatrol/util/Helpers.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/util/Helpers.scala
@@ -23,7 +23,8 @@ object Helpers {
   }
 
   /**
-    * Scrub a string passed in and return value
+    * The value could be malformed and may contain special characters. So lets scrub it and return the value
+    * if anything was found
     * @param toScrub
     * @return
     */

--- a/core/src/test/scala/com/lookout/borderpatrol/test/DestinationValidatorSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/DestinationValidatorSpec.scala
@@ -1,0 +1,31 @@
+package com.lookout.borderpatrol.test
+
+import com.google.common.net.InternetDomainName
+import com.lookout.borderpatrol.auth.DestinationValidator
+
+/**
+  * Created by rikesh.chouhan on 8/4/16.
+  */
+class DestinationValidatorSpec extends BorderPatrolSuite {
+
+  val validDomains = Set("www.yahoo.com", "www.google.com", "localhost")
+  val allowedDomains: Set[InternetDomainName] = validDomains map (InternetDomainName.from(_))
+  val destinationValidator = DestinationValidator(allowedDomains)
+
+  it should "Return the string as is when it is a valid URL" in {
+    destinationValidator.matchesValidHosts("http://www.yahoo.com") should be (Some("http://www.yahoo.com"))
+  }
+
+  it should "Return None when the host is not a valid entry" in {
+    destinationValidator.matchesValidHosts("http://www.cnn.com") should be (None)
+  }
+
+  it should "Return the string when it is a fragment or path instead of url" in {
+    destinationValidator.matchesValidHosts("/dummy/path") should be (Some("/dummy/path"))
+  }
+
+  it should "Return the string when it is a plain string matching a host entry" in {
+    destinationValidator.matchesValidHosts("localhost") should be (Some("localhost"))
+  }
+
+}

--- a/core/src/test/scala/com/lookout/borderpatrol/test/DestinationValidatorSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/DestinationValidatorSpec.scala
@@ -13,19 +13,19 @@ class DestinationValidatorSpec extends BorderPatrolSuite {
   val destinationValidator = DestinationValidator(allowedDomains)
 
   it should "Return the string as is when it is a valid URL" in {
-    destinationValidator.matchesValidHosts("http://www.yahoo.com") should be (Some("http://www.yahoo.com"))
+    destinationValidator.checkHosts("http://www.yahoo.com") should be (Some("http://www.yahoo.com"))
   }
 
   it should "Return None when the host is not a valid entry" in {
-    destinationValidator.matchesValidHosts("http://www.cnn.com") should be (None)
+    destinationValidator.checkHosts("http://www.cnn.com") should be (None)
   }
 
   it should "Return the string when it is a fragment or path instead of url" in {
-    destinationValidator.matchesValidHosts("/dummy/path") should be (Some("/dummy/path"))
+    destinationValidator.checkHosts("/dummy/path") should be (Some("/dummy/path"))
   }
 
   it should "Return the string when it is a plain string matching a host entry" in {
-    destinationValidator.matchesValidHosts("localhost") should be (Some("localhost"))
+    destinationValidator.checkHosts("localhost") should be (Some("localhost"))
   }
 
 }

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
@@ -1,5 +1,6 @@
 package com.lookout.borderpatrol.test.auth
 
+import com.google.common.net.InternetDomainName
 import com.lookout.borderpatrol.{BpCommunicationError, BpNotFoundRequest, ServiceIdentifier}
 import com.lookout.borderpatrol.auth._
 import com.lookout.borderpatrol.sessionx.SessionStores.MemcachedStore
@@ -53,6 +54,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
       Future.exception(new Exception("oopsie"))
     }
   }
+  val validHosts: Set[InternetDomainName] = Set(InternetDomainName.from("enterprise.example.com"))
+  val destinationValidator = DestinationValidator(validHosts)
 
   behavior of "rewriteRequest"
 
@@ -467,7 +470,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = reqPost("enterprise", cust1.loginManager.loginConfirm.toString, Buf.Empty)
 
     // Original request
-    val output = (SendToIdentityProvider(workingMap, sessionStore) andThen testService)(
+    val output = (SendToIdentityProvider(workingMap, sessionStore, destinationValidator) andThen testService)(
       SessionIdRequest(request, cust1, Some(one), Some(sessionId)))
 
     //  Validate
@@ -487,7 +490,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = reqPost("enterprise", cust1.loginManager.loginConfirm.toString, Buf.Empty)
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen testService)(
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
       SessionIdRequest(request, cust1, Some(one), None))
 
     //  Validate
@@ -508,7 +511,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
       ("destination" -> "blah"))
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen testService)(
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
       SessionIdRequest(request, cust1, Some(one), None))
 
     //  Validate
@@ -531,7 +534,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     request.addCookie(cooki)
 
     // Execute
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen testService)(
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
       SessionIdRequest(request, cust1, Some(one), Some(sessionId)))
 
     // Validate
@@ -550,7 +553,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = req("enterprise", "ent")
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen testService)(
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
       SessionIdRequest(request, cust1, Some(one), Some(sessionId)))
 
     // Validate
@@ -574,7 +577,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     request.accept = Seq("application/json")
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen testService)(
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
       SessionIdRequest(request, cust1, Some(one), Some(sessionId)))
 
     // Validate
@@ -599,7 +602,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     request.headerMap.add("X-Forwarded-Proto", "https")
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen testService)(
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
       SessionIdRequest(request, cust2, Some(two), Some(sessionId)))
 
     // Validate
@@ -622,7 +625,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = req("enterprise", "check")
 
     // Execute
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen testService)(
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
       SessionIdRequest(request, cust1, Some(unproCheckpointSid), Some(sessionId)))
 
     // Validate
@@ -641,7 +644,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = req("enterprise", "unknown")
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen testService)(
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
       SessionIdRequest(request, cust1, None, Some(sessionId)))
 
     // Validate
@@ -661,7 +664,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = req("enterprise", "ent")
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen testService)(
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
       SessionIdRequest(request, cust1, Some(one), None))
 
     // Validate
@@ -683,7 +686,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = req("enterprise", "check")
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen testService)(
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
       SessionIdRequest(request, cust1, Some(unproCheckpointSid), None))
 
     // Validate
@@ -699,7 +702,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = req("enterprise", "unknown")
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen testService)(
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
       SessionIdRequest(request, cust1, None, None))
 
     // Validate
@@ -722,7 +725,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = reqPost("enterprise", cust1.loginManager.loginConfirm.toString, Buf.Empty)
 
     // Execute
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen sessionIdFilterTestService)(
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen sessionIdFilterTestService)(
       SessionIdRequest(request, cust1, Some(one), Some(sessionId)))
 
     // Validate
@@ -745,7 +748,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = reqPost("enterprise", cust1.loginManager.loginConfirm.toString, Buf.Empty)
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, mockSessionStore) andThen testService)(
+    val output = (SendToIdentityProvider(identityProviderMap, mockSessionStore, destinationValidator) andThen testService)(
       SessionIdRequest(request, cust1, Some(one), None))
 
     // Verify
@@ -1019,7 +1022,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     request.addCookie(cooki2)
 
     // Execute
-    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen LogoutService(sessionStore))(
+    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen LogoutService(sessionStore, destinationValidator))(
       request)
 
     // Validate
@@ -1037,7 +1040,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = req("enterprise", "/logout")
 
     // Execute
-    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen LogoutService(sessionStore))(
+    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen LogoutService(sessionStore, destinationValidator))(
       request)
 
     // Validate
@@ -1052,7 +1055,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     request.accept = Seq("application/json")
 
     // Execute
-    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen LogoutService(sessionStore))(
+    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen LogoutService(sessionStore, destinationValidator))(
       request)
 
     // Validate
@@ -1068,7 +1071,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     request.accept = Seq("application/json")
 
     // Execute
-    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen LogoutService(sessionStore))(
+    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen LogoutService(sessionStore, destinationValidator))(
       request)
 
     // Validate

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
@@ -55,7 +55,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     }
   }
   val validHosts: Set[InternetDomainName] = Set(InternetDomainName.from("enterprise.example.com"))
-  val destinationValidator = DestinationValidator(validHosts)
+  implicit val destinationValidator = DestinationValidator(validHosts)
 
   behavior of "rewriteRequest"
 
@@ -470,7 +470,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = reqPost("enterprise", cust1.loginManager.loginConfirm.toString, Buf.Empty)
 
     // Original request
-    val output = (SendToIdentityProvider(workingMap, sessionStore, destinationValidator) andThen testService)(
+    val output = (SendToIdentityProvider(workingMap, sessionStore) andThen testService)(
       SessionIdRequest(request, cust1, Some(one), Some(sessionId)))
 
     //  Validate
@@ -490,8 +490,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = reqPost("enterprise", cust1.loginManager.loginConfirm.toString, Buf.Empty)
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
-      SessionIdRequest(request, cust1, Some(one), None))
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen
+      testService)(SessionIdRequest(request, cust1, Some(one), None))
 
     //  Validate
     Await.result(output).status should be(Status.Ok)
@@ -511,8 +511,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
       ("destination" -> "blah"))
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
-      SessionIdRequest(request, cust1, Some(one), None))
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen
+      testService)(SessionIdRequest(request, cust1, Some(one), None))
 
     //  Validate
     Await.result(output).status should be(Status.Ok)
@@ -534,8 +534,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     request.addCookie(cooki)
 
     // Execute
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
-      SessionIdRequest(request, cust1, Some(one), Some(sessionId)))
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen
+      testService)(SessionIdRequest(request, cust1, Some(one), Some(sessionId)))
 
     // Validate
     Await.result(output).status should be(Status.NotAcceptable)
@@ -553,8 +553,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = req("enterprise", "ent")
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
-      SessionIdRequest(request, cust1, Some(one), Some(sessionId)))
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen
+      testService)(SessionIdRequest(request, cust1, Some(one), Some(sessionId)))
 
     // Validate
     val resp = Await.result(output)
@@ -577,8 +577,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     request.accept = Seq("application/json")
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
-      SessionIdRequest(request, cust1, Some(one), Some(sessionId)))
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen
+      testService)(SessionIdRequest(request, cust1, Some(one), Some(sessionId)))
 
     // Validate
     val resp = Await.result(output)
@@ -602,8 +602,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     request.headerMap.add("X-Forwarded-Proto", "https")
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
-      SessionIdRequest(request, cust2, Some(two), Some(sessionId)))
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen
+      testService)(SessionIdRequest(request, cust2, Some(two), Some(sessionId)))
 
     // Validate
     val resp = Await.result(output)
@@ -625,8 +625,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = req("enterprise", "check")
 
     // Execute
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
-      SessionIdRequest(request, cust1, Some(unproCheckpointSid), Some(sessionId)))
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen
+      testService)(SessionIdRequest(request, cust1, Some(unproCheckpointSid), Some(sessionId)))
 
     // Validate
     Await.result(output).status should be(Status.NotAcceptable)
@@ -644,8 +644,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = req("enterprise", "unknown")
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
-      SessionIdRequest(request, cust1, None, Some(sessionId)))
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen
+      testService)(SessionIdRequest(request, cust1, None, Some(sessionId)))
 
     // Validate
     val resp = Await.result(output)
@@ -664,8 +664,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = req("enterprise", "ent")
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
-      SessionIdRequest(request, cust1, Some(one), None))
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen
+      testService)(SessionIdRequest(request, cust1, Some(one), None))
 
     // Validate
     val resp = Await.result(output)
@@ -686,8 +686,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = req("enterprise", "check")
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
-      SessionIdRequest(request, cust1, Some(unproCheckpointSid), None))
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen
+      testService)(SessionIdRequest(request, cust1, Some(unproCheckpointSid), None))
 
     // Validate
     Await.result(output).status should be(Status.NotAcceptable)
@@ -702,8 +702,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = req("enterprise", "unknown")
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen testService)(
-      SessionIdRequest(request, cust1, None, None))
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen
+      testService)(SessionIdRequest(request, cust1, None, None))
 
     // Validate
     val resp = Await.result(output)
@@ -725,8 +725,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = reqPost("enterprise", cust1.loginManager.loginConfirm.toString, Buf.Empty)
 
     // Execute
-    val output = (SendToIdentityProvider(identityProviderMap, sessionStore, destinationValidator) andThen sessionIdFilterTestService)(
-      SessionIdRequest(request, cust1, Some(one), Some(sessionId)))
+    val output = (SendToIdentityProvider(identityProviderMap, sessionStore) andThen
+      sessionIdFilterTestService)(SessionIdRequest(request, cust1, Some(one), Some(sessionId)))
 
     // Validate
     val caught = the[BpIdentityProviderError] thrownBy {
@@ -748,8 +748,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = reqPost("enterprise", cust1.loginManager.loginConfirm.toString, Buf.Empty)
 
     // Original request
-    val output = (SendToIdentityProvider(identityProviderMap, mockSessionStore, destinationValidator) andThen testService)(
-      SessionIdRequest(request, cust1, Some(one), None))
+    val output = (SendToIdentityProvider(identityProviderMap, mockSessionStore)
+      andThen testService)(SessionIdRequest(request, cust1, Some(one), None))
 
     // Verify
     val caught = the[Exception] thrownBy {
@@ -1022,8 +1022,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     request.addCookie(cooki2)
 
     // Execute
-    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen LogoutService(sessionStore, destinationValidator))(
-      request)
+    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen
+      LogoutService(sessionStore))(request)
 
     // Validate
     Await.result(output).status should be (Status.Found)
@@ -1040,8 +1040,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     val request = req("enterprise", "/logout")
 
     // Execute
-    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen LogoutService(sessionStore, destinationValidator))(
-      request)
+    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen
+      LogoutService(sessionStore))(request)
 
     // Validate
     Await.result(output).status should be (Status.Found)
@@ -1055,8 +1055,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     request.accept = Seq("application/json")
 
     // Execute
-    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen LogoutService(sessionStore, destinationValidator))(
-      request)
+    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen
+      LogoutService(sessionStore))(request)
 
     // Validate
     Await.result(output).status should be (Status.Ok)
@@ -1071,8 +1071,8 @@ class BorderAuthSpec extends BorderPatrolSuite {
     request.accept = Seq("application/json")
 
     // Execute
-    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen LogoutService(sessionStore, destinationValidator))(
-      request)
+    val output = (ExceptionFilter() andThen CustomerIdFilter(serviceMatcher) andThen
+      LogoutService(sessionStore))(request)
 
     // Validate
     Await.result(output).status should be (Status.Ok)

--- a/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/auth/BorderAuthSpec.scala
@@ -1077,7 +1077,7 @@ class BorderAuthSpec extends BorderPatrolSuite {
     // Validate
     Await.result(output).status should be (Status.Ok)
     Await.result(output).contentType.get should include("application/json")
-    Await.result(output).contentString should include(s""""redirect_url" : "http://www.example.com"""")
+    Await.result(output).contentString should include(s""""redirect_url" : "/abc"""")
     Await.result(output).cookies.get(SignedId.sessionIdCookieName) should be (None)
   }
 }

--- a/core/src/test/scala/com/lookout/borderpatrol/test/util/HelpersSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/util/HelpersSpec.scala
@@ -91,4 +91,12 @@ class HelpersSpec extends BorderPatrolSuite {
     val req48 = toPostRequest("destination=\n\r/abc")
     scrubQueryParams(req48.params, "destination") should be(Some("/abc"))
   }
+
+  behavior of "scrubAString"
+  it should "scrub a string of special chars" in {
+    val dirtyValue = "destination\ndoo"
+    scrubAString(dirtyValue) should be (Some("destination"))
+    val dirtyValue2 = "\rabc"
+    scrubAString(dirtyValue2) should be (Some("abc"))
+  }
 }

--- a/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/service.scala
@@ -79,7 +79,7 @@ object service {
                        secretStore: SecretStoreApi): Service[Request, Response] = {
     val serviceMatcher = ServiceMatcher(config.customerIdentifiers, config.serviceIdentifiers)
     val notFoundService = Service.mk[SessionIdRequest, Response] { req => Response(Status.NotFound).toFuture }
-    val destinationValidator = DestinationValidator(config.allowedDomains)
+    implicit val destinationValidator = DestinationValidator(config.allowedDomains)
     val serviceChainFront: Filter[Request, Response, Request, Response] =
       /* Validate host if present to be present in pre-configured list*/
       HostHeaderFilter(config.allowedDomains) andThen
@@ -96,7 +96,7 @@ object service {
       case "/logout" =>
         serviceChainFront andThen
           CustomerIdFilter(serviceMatcher) andThen /* Validate that its our service */
-          LogoutService(config.sessionStore, destinationValidator)
+          LogoutService(config.sessionStore)
 
       case _ =>
         serviceChainFront andThen
@@ -107,8 +107,7 @@ object service {
           /* Get or allocate Session/SignedId */
           SessionIdFilter(serviceMatcher, config.sessionStore) andThen
           /* If unauthenticated, send it to Identity Provider or login page */
-          SendToIdentityProvider(identityProviderChainMap(config.sessionStore), config.sessionStore,
-            destinationValidator) andThen
+          SendToIdentityProvider(identityProviderChainMap(config.sessionStore), config.sessionStore) andThen
           /* If authenticated and protected service, send it via Access Issuer chain */
           SendToAccessIssuer(accessIssuerChainMap(config.sessionStore)) andThen
           /* Authenticated or not, send it to unprotected service, if its destined to that */

--- a/security/src/test/scala/com/lookout/borderpatrol/test/security/SecureHeadersSpec.scala
+++ b/security/src/test/scala/com/lookout/borderpatrol/test/security/SecureHeadersSpec.scala
@@ -5,7 +5,7 @@ import com.lookout.borderpatrol.security.SecureHeaderFilter
 import com.lookout.borderpatrol.security.SecureHeaders
 import com.lookout.borderpatrol.test._
 import com.twitter.finagle.Service
-import com.twitter.finagle.http.{HeaderMap, Response, Request, Status}
+import com.twitter.finagle.http.{Response, Request, Status}
 import com.twitter.util.Future
 
 class SecureHeadersSpec extends BorderPatrolSuite {


### PR DESCRIPTION
Push changes to check if host name for a "destination" is allowed.
Caller can proceed on action with value obtained from DestinationValidator

Fixes #188 