### PR TITLE
Consolidated and updated AAD token access methods

### DIFF
--- a/auth/src/main/scala/com/lookout/borderpatrol/auth/tokenmaster/OAuth2.scala
+++ b/auth/src/main/scala/com/lookout/borderpatrol/auth/tokenmaster/OAuth2.scala
@@ -144,7 +144,7 @@ object OAuth2 {
      * @return
      */
     def codeToClaimsSet(req: BorderRequest, loginManager: OAuth2LoginManagerMixin):
-      Future[(JWTClaimsSet, JWTClaimsSet)] = {
+      Future[(String, JWTClaimsSet, JWTClaimsSet)] = {
       for {
         aadToken <- loginManager.codeToToken(req).flatMap(res => res.status match {
           //  Parse for Tokens if Status.Ok
@@ -161,7 +161,7 @@ object OAuth2 {
         })
         idClaimSet <- wrapFuture({() => PlainJWT.parse(aadToken.idToken).getJWTClaimsSet}, BpTokenParsingError.apply)
         accessClaimSet <- getClaimsSet(req, loginManager, aadToken.accessToken)
-      } yield (accessClaimSet, idClaimSet)
+      } yield (aadToken.accessToken, accessClaimSet, idClaimSet)
     }
   }
 }

--- a/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/OAuth2Spec.scala
+++ b/auth/src/test/scala/com/lookout/borderpatrol/auth/tokenmaster/OAuth2Spec.scala
@@ -185,8 +185,8 @@ class OAuth2Spec extends BorderPatrolSuite {
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, umbrellaLoginManager)
 
       // Validate
-      Await.result(output)._1.getSubject should be("abc123")
-      Await.result(output)._1.getStringClaim("upn") should be("test@example.com")
+      Await.result(output)._2.getSubject should be("abc123")
+      Await.result(output)._2.getStringClaim("upn") should be("test@example.com")
     } finally {
       server.close()
     }
@@ -238,8 +238,8 @@ class OAuth2Spec extends BorderPatrolSuite {
       val output = new OAuth2CodeVerify().codeToClaimsSet(sessionIdRequest, umbrellaLoginManager)
 
       // Validate
-      Await.result(output)._1.getSubject should be("abc123")
-      Await.result(output)._1.getStringClaim("upn") should be("test@example.com")
+      Await.result(output)._2.getSubject should be("abc123")
+      Await.result(output)._2.getStringClaim("upn") should be("test@example.com")
     } finally {
       server.close()
     }
@@ -282,8 +282,8 @@ class OAuth2Spec extends BorderPatrolSuite {
       val output = oAuth2CodeVerify.codeToClaimsSet(sessionIdRequest, umbrellaLoginManager)
 
       // Validate
-      Await.result(output)._1.getSubject should be("abc123")
-      Await.result(output)._1.getStringClaim("upn") should be("test@example.com")
+      Await.result(output)._2.getSubject should be("abc123")
+      Await.result(output)._2.getStringClaim("upn") should be("test@example.com")
     } finally {
       server.close()
     }

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.40-SNAPSHOT"
+lazy val Version = "0.2.41-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
+++ b/example/src/main/scala/com/lookout/borderpatrol/example/BorderPatrolApp.scala
@@ -8,6 +8,7 @@ import com.lookout.borderpatrol.server._
 import com.twitter.conversions.storage._
 import com.twitter.finagle.Http
 import com.twitter.finagle.Http.param.MaxHeaderSize
+import com.twitter.finagle.tracing.NullTracer
 import com.twitter.server.TwitterServer
 import com.twitter.util.Await
 
@@ -50,6 +51,7 @@ object BorderPatrolApp extends TwitterServer with ServerConfigMixin {
       .configured(MaxHeaderSize(32.kilobytes)) /* Sum of all headers should be less than 32k */
       .withMaxRequestSize(50.megabytes) /* Size of request body should be less than 50M */
       .withMaxResponseSize(50.megabytes) /* Size of response body should be less than 50M */
+      .withTracer(NullTracer)
       .serve(s":${serverConfig.listeningPort}", MainServiceChain)
     val server2 = Http.serve(s":${serverConfig.listeningPort+1}", getMockRoutingService)
     Await.all(server1, server2)


### PR DESCRIPTION
Also,
- using null tracer (disable zipkin)
- Use default port if no port specified in the URL