### PR TITLE
Add OptionsFilter to handle HTTP OPTIONS request

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.41-SNAPSHOT"
+lazy val Version = "0.2.42-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/server/src/main/scala/com/lookout/borderpatrol/server/AccessLogFilter.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/AccessLogFilter.scala
@@ -58,7 +58,7 @@ case class AccessLogFilter(logDestination: String, fileSizeInMegaBytes: Long, fi
     val requestContentLength = req.contentLength.getOrElse("-")
     for {
       resp <- service(req)
-      _<- Future(logger.log(accessLogLevel,
+      _ <- Future(logger.log(accessLogLevel,
         /* IP Address */
         s"${requestIPAddress}\t"+
           /* Start Time */


### PR DESCRIPTION
Also,
- remove methods from RoutingService
- Disable failfast if upstream is ELB
- Synchronize the Endpoint cache to ensure only 1 instance of Client
  created per endpoint