### PR TITLE
Allow one or more unprotected paths on the main anchor path

### DIFF
--- a/bpConfig.json
+++ b/bpConfig.json
@@ -89,7 +89,9 @@
     {
       "hosts": ["http://localhost:8081"],
       "path": "/z",
-      "protected": false,
+      "unprotectedPaths": [
+        "/"
+      ],
       "name": "login"
     }
   ],

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
-lazy val Version = "0.2.44-SNAPSHOT"
+lazy val Version = "0.2.45-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   organization := "com.lookout",

--- a/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
+++ b/core/src/main/scala/com/lookout/borderpatrol/ServiceIdentifier.scala
@@ -13,12 +13,16 @@ import com.twitter.finagle.http.path.Path
  * @param path The external url path prefix that routes to the internal service
  * @param rewritePath The (optional) internal url path prefix to the internal service. If present,
  *                    it replaces the external path in the Request URI
- * @param protekted The service is protected or unprotected (i.e. does not go through access issuer)
+ * @param unprotectedPaths The list of unprotected/unauthenticated paths (i.e. does not go through access issuer)
+ *                         anchored on the "path"
  */
 case class ServiceIdentifier(name: String, hosts: Set[URL], path: Path, rewritePath: Option[Path],
-                             protekted: Boolean) {
-  def isServicePath(p: Path): Boolean =
-    p.startsWith(path)
+                             unprotectedPaths: Set[Path]) {
+  def isServicePath(p: Path): Boolean = p.startsWith(path)
+  def isUnprotected(s: String): Boolean = unprotectedPaths.exists { p =>
+    val components = path.toList ++ p.toList
+    (Path(s).toList take components.length) == components
+  }
   lazy val endpoint: Endpoint = SimpleEndpoint(name, path, hosts)
 }
 

--- a/core/src/test/scala/com/lookout/borderpatrol/test/ServiceMatcherSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/ServiceMatcherSpec.scala
@@ -7,11 +7,11 @@ import com.twitter.finagle.http.path.Path
 class ServiceMatcherSpec extends BorderPatrolSuite {
   import coreTestHelpers._
 
-  val sOneOne = ServiceIdentifier("eOne", urls, Path("/ent1"), None, true)
-  val sOneTwo = ServiceIdentifier("eTwo", urls, Path("/ent2"), None, true)
-  val sTwo = ServiceIdentifier("two", urls, Path("/api"), None, true)
-  val sThree = ServiceIdentifier("three", urls, Path("/apis"), None, true)
-  val sFour = ServiceIdentifier("four", urls, Path("/apis/test"), None, true)
+  val sOneOne = ServiceIdentifier("eOne", urls, Path("/ent1"), None, Set.empty)
+  val sOneTwo = ServiceIdentifier("eTwo", urls, Path("/ent2"), None, Set.empty)
+  val sTwo = ServiceIdentifier("two", urls, Path("/api"), None, Set.empty)
+  val sThree = ServiceIdentifier("three", urls, Path("/apis"), None, Set.empty)
+  val sFour = ServiceIdentifier("four", urls, Path("/apis/test"), None, Set.empty)
   val serviceIds = Set(sOneOne, sOneTwo, sTwo, sThree, sFour)
   val cOne = CustomerIdentifier("enterprise", "c1-guid", sOneOne, test1LoginManager)
   val cTwo = CustomerIdentifier("api", "c2-guid", two, test2LoginManager)

--- a/core/src/test/scala/com/lookout/borderpatrol/test/coreTestHelpers.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/coreTestHelpers.scala
@@ -84,12 +84,12 @@ object coreTestHelpers {
     test2LoginManager.asInstanceOf[LoginManager])
 
   // sids
-  val one = ServiceIdentifier("one", urls, Path("/ent"), None, true)
-  val oneTwo = ServiceIdentifier("oneTwo", urls, Path("/ent2"), None, true)
-  val two = ServiceIdentifier("two", urls, Path("/umb"), Some(Path("/broken/umb")), true)
-  val three = ServiceIdentifier("three", urls, Path("/rain"), None, true)
-  val unproCheckpointSid = ServiceIdentifier("login", urls, Path("/check"), None, false)
-  val proCheckpointSid = ServiceIdentifier("checkpoint", urls, Path("/check/that"), None, true)
+  val one = ServiceIdentifier("one", urls, Path("/ent"), None, Set.empty)
+  val oneTwo = ServiceIdentifier("oneTwo", urls, Path("/ent2"), None, Set.empty)
+  val two = ServiceIdentifier("two", urls, Path("/umb"), Some(Path("/broken/umb")), Set.empty)
+  val three = ServiceIdentifier("three", urls, Path("/rain"), None, Set.empty)
+  val unproCheckpointSid = ServiceIdentifier("login", urls, Path("/check"), None, Set(Path("/")))
+  val proCheckpointSid = ServiceIdentifier("checkpoint", urls, Path("/check/that"), None, Set.empty)
 
   // cids
   val cust1 = CustomerIdentifier("enterprise", "cust1-guid", one, test1LoginManager)

--- a/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionStoreSpec.scala
+++ b/core/src/test/scala/com/lookout/borderpatrol/test/sessionx/SessionStoreSpec.scala
@@ -45,13 +45,8 @@ class SessionStoreSpec extends BorderPatrolSuite {
       store.get[http.Request](reqSession.id).results.get.data.uri shouldEqual reqSession.data.uri
     }
 
-    it should s"return a Future exception when decoding to wrong type in $store" in {
-      // try to make an Session[Int] => Session[http.Request]
-      store.get[http.Request](intSession.id).isThrowable should be(true)
-
-      /* TODO: Disallow this: Int -> Buf -> String
-      isThrow(store.get[Int](strSession.id)) should be(false)
-      */
+    it should s"return a None when decoding to wrong type in $store" in {
+      store.get[http.Request](intSession.id).results should be(None)
     }
 
     it should s"delete stored values in $store" in {

--- a/server/src/main/scala/com/lookout/borderpatrol/server/AccessLogFilter.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/AccessLogFilter.scala
@@ -62,7 +62,7 @@ case class AccessLogFilter(logDestination: String, fileSizeInMegaBytes: Long, fi
         /* IP Address */
         s"${requestIPAddress}\t"+
           /* Start Time */
-          s"${startTime.format("[yyyy/MM/dd:hh:mm:ss.sss]")}\t"+
+          s"${startTime.format("[yyyy/MM/dd:hh:mm:ss.SSS]")}\t"+
           /* Reuest Method (GET/POST) */
           s"${requestMethod}\t"+
           /* Request Host */

--- a/server/src/main/scala/com/lookout/borderpatrol/server/Config.scala
+++ b/server/src/main/scala/com/lookout/borderpatrol/server/Config.scala
@@ -89,7 +89,7 @@ object Config {
       ("hosts", sid.hosts.asJson),
       ("path", sid.path.asJson),
       ("rewritePath", sid.rewritePath.asJson),
-      ("protected", sid.protekted.asJson)))
+      ("unprotectedPaths", sid.unprotectedPaths.asJson)))
   }
   implicit val decodeServiceIdentifier: Decoder[ServiceIdentifier] =
     Decoder.instance { c =>
@@ -98,8 +98,8 @@ object Config {
         hosts <- c.downField("hosts").as[Set[URL]]
         path <- c.downField("path").as[Path]
         rewritePathOption <- c.downField("rewritePath").as[Option[Path]]
-        protectedOption <- c.downField("protected").as[Option[Boolean]]
-      } yield ServiceIdentifier(name, hosts, path, rewritePathOption, protectedOption.getOrElse(true))
+        unprotectedPaths <- c.downField("unprotectedPaths").as[Option[Set[Path]]]
+      } yield ServiceIdentifier(name, hosts, path, rewritePathOption, unprotectedPaths.getOrElse(Set.empty[Path]))
     }
 
   // Encoder/Decoder for CustomerIdentifier

--- a/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
+++ b/server/src/test/scala/com/lookout/borderpatrol/server/ConfigSpec.scala
@@ -1,7 +1,6 @@
 package com.lookout.borderpatrol.server
 
 import java.net.URL
-
 import com.google.common.net.InternetDomainName
 import com.lookout.borderpatrol.auth.tokenmaster._
 import com.lookout.borderpatrol.auth.tokenmaster.LoginManagers._
@@ -11,14 +10,14 @@ import com.lookout.borderpatrol.sessionx._
 import com.lookout.borderpatrol.test._
 import com.lookout.borderpatrol._
 import com.twitter.finagle.memcached
-import com.twitter.finagle.http.path.Path
+import com.twitter.finagle.http.path.{Path, Root}
 import cats.data.Xor
 import io.circe._
 import io.circe.jawn._
 import io.circe.generic.auto._
 import io.circe.syntax._
-
 import scala.reflect.io.File
+
 
 class ConfigSpec extends BorderPatrolSuite {
   import coreTestHelpers._
@@ -158,8 +157,8 @@ class ConfigSpec extends BorderPatrolSuite {
 
   it should "return a Set with errors if duplicate paths are configured in serviceIdentifiers config" in {
     val output = validateServiceIdentifierConfig("serviceIdentifiers",
-      sids + ServiceIdentifier("some", urls, Path("/ent"), None, false)
-        + ServiceIdentifier("some", urls, Path("/some"), None, false))
+      sids + ServiceIdentifier("some", urls, Path("/ent"), None, Set.empty)
+        + ServiceIdentifier("some", urls, Path("/some"), None, Set(Root)))
     output should contain ("Duplicate entries for key (path) are found in the field: serviceIdentifiers")
   }
 


### PR DESCRIPTION
- Currently service can be either defined as protected or unprotected. But
  thats not sufficient, as each service may have one or more such paths (pockets)
- By default the anchor path would be protected
- A set of unprotected paths, if specified, will create the necessary holes